### PR TITLE
[MMM-22507] add harness

### DIFF
--- a/.harness/CI.yaml
+++ b/.harness/CI.yaml
@@ -1,0 +1,159 @@
+pipeline:
+  name: CI
+  identifier: CI
+  projectIdentifier: datarobotopentelemetry
+  orgIdentifier: MMM
+  tags: {}
+  properties:
+    ci:
+      codebase:
+        connectorRef: account.svc_harness_git1
+        repoName: datarobot-opentelemetry
+        build: <+input>
+  stages:
+    - stage:
+        name: Git Hash
+        identifier: Git_Hash
+        description: ""
+        type: CI
+        spec:
+          cloneCodebase: true
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Git Hash
+                  identifier: Git_Hash
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: alpine/git
+                    shell: Sh
+                    command: export GIT_HASH_SHORT=$(git rev-parse --short HEAD)
+                    outputVariables:
+                      - name: GIT_HASH_SHORT
+          infrastructure:
+            type: KubernetesDirect
+            spec:
+              connectorRef: account.cigeneral
+              namespace: harness-delegate-ng
+              automountServiceAccountToken: true
+              nodeSelector: {}
+              os: Linux
+    - parallel:
+        - stage:
+            name: Linting
+            identifier: CI
+            type: CI
+            spec:
+              cloneCodebase: true
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              execution:
+                steps:
+                  - parallel:
+                      - step:
+                          type: Run
+                          name: Ruff Linting
+                          identifier: Ruff_Linting
+                          spec:
+                            connectorRef: account.dockerhub_datarobot_read
+                            image: datarobotdev/datarobotopentelemetry:ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
+                            shell: Sh
+                            command: |-
+                              echo "TODO Add Ruff Linting"
+                      - step:
+                          type: Run
+                          name: Ruff Formatting
+                          identifier: Black_Linting
+                          spec:
+                            connectorRef: account.dockerhub_datarobot_read
+                            image: datarobotdev/datarobotopentelemetry:ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
+                            shell: Sh
+                            command: |-
+                              echo "TODO Add Ruff Formatting"
+                      - step:
+                          type: Run
+                          name: Run Mypy
+                          identifier: Run_Mypy
+                          spec:
+                            connectorRef: account.dockerhub_datarobot_read
+                            image: datarobotdev/datarobotopentelemetry:ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
+                            shell: Sh
+                            command: |-
+                              echo "TODO Add Mypy"
+              caching:
+                enabled: false
+                paths: []
+        - stage:
+            name: Unit Test
+            identifier: Unit_Test
+            type: CI
+            spec:
+              cloneCodebase: true
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: Run Unit Test
+                      identifier: Run_Unit_Test
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: datarobotdev/datarobotopentelemetry:ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
+                        shell: Sh
+                        command: |-
+                          echo "TODO Add Unit Test"
+                        reports:
+                          type: JUnit
+                          spec:
+                            paths:
+                              - /harness/test_results/unit-test-results.xml
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              caching:
+                enabled: false
+                paths: []
+        - stage:
+            name: Source Code License Check
+            identifier: License_Check
+            type: CI
+            spec:
+              cloneCodebase: true
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: License Check
+                      identifier: License_Check
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: ghcr.io/apache/skywalking-eyes/license-eye
+                        shell: Sh
+                        command: |-
+                          echo "Run License Check"
+                          license-eye -v info -c .licenserc.yaml header check
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              caching:
+                enabled: false
+                paths: []
+              slsa_provenance:
+                enabled: false
+            description: ""

--- a/.harness/inputsetbranch.yaml
+++ b/.harness/inputsetbranch.yaml
@@ -1,0 +1,14 @@
+inputSet:
+  name: input-set-branch
+  identifier: inputsetbranch
+  orgIdentifier: MMM
+  projectIdentifier: datarobotopentelemetry
+  pipeline:
+    identifier: CI
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>

--- a/.harness/inputsetpr.yaml
+++ b/.harness/inputsetpr.yaml
@@ -1,0 +1,14 @@
+inputSet:
+  name: input-set-pr
+  identifier: inputsetpr
+  orgIdentifier: MMM
+  projectIdentifier: datarobotopentelemetry
+  pipeline:
+    identifier: CI
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,56 @@
+# Configuration for the copyright headers added to source code files in the repo. Used by the skywalking-eyes tool.
+# See dev-docs/docs/developer_guide/workflows/copyright.md for details.
+# Also, additional syntax options for this configuration file that are supported by the tool are
+# described in the tool's own documentation here: https://github.com/apache/skywalking-eyes.
+#
+# USAGE
+# -------
+# To check files:
+#    > docker run  --rm -v $(pwd):/github/workspace ghcr.io/apache/skywalking-eyes/license-eye:785bb7f3810572d6912666b4f64bad28e4360799 -v info -c .licenserc.yaml header check
+# To fix files automatically:
+#    > docker run  --rm -v $(pwd):/github/workspace ghcr.io/apache/skywalking-eyes/license-eye:785bb7f3810572d6912666b4f64bad28e4360799 -v info -c .licenserc.yaml header fix
+#
+header:
+  license:
+    spdx-id: N/A
+    copyright-owner: N/A
+    content: |-
+
+      Copyright 2026 DataRobot, Inc. and its affiliates.
+
+      All rights reserved.
+
+      DataRobot, Inc. Confidential.
+
+      This is unpublished proprietary source code of DataRobot, Inc.
+      and its affiliates.
+
+      The copyright notice above does not evidence any actual or intended
+      publication of such source code.
+    pattern: |-
+
+      Copyright [0-9]{4} DataRobot, Inc\. and its affiliates\.
+
+      All rights reserved\.
+
+      DataRobot, Inc\. Confidential\.
+
+      This is unpublished proprietary source code of DataRobot, Inc\.
+      and its affiliates\.
+
+      The copyright notice above does not evidence any actual or intended
+      publication of such source code\.
+
+  paths:
+    - '**/*.py'
+
+  paths-ignore:
+    # these files/directories should not be analyzed
+    #
+    - '.licenserc.yaml'
+    - 'env'
+    - '__init__.py'
+    - '**/*_pb2.py'
+    - '**/*_pb2_grpc.py'
+
+  comment: on-failure


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only adds CI configuration and a license-header config file without changing runtime/library code. Main risk is CI behavior/coverage being incomplete due to placeholder lint/test commands.
> 
> **Overview**
> Adds a new Harness CI pipeline (`.harness/CI.yaml`) that computes a short git hash and then runs parallel stages for *linting*, *unit tests*, and an Apache SkyWalking Eyes **license header check**.
> 
> Introduces branch/PR input sets (`.harness/inputsetbranch.yaml`, `.harness/inputsetpr.yaml`) and a `.licenserc.yaml` defining the required proprietary header for Python files and ignore patterns; lint/test steps are currently placeholders (`echo "TODO"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b72cb51807d8fe45073e893566670b7ecf1972a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->