### PR TITLE
[MMM-22507] changes

### DIFF
--- a/.harness/CI.yaml
+++ b/.harness/CI.yaml
@@ -39,6 +39,46 @@ pipeline:
               automountServiceAccountToken: true
               nodeSelector: {}
               os: Linux
+                      - stage:
+            name: Build Docker Image CI
+            identifier: Build_Docker_Image
+            description: ""
+            type: CI
+            spec:
+              cloneCodebase: true
+              execution:
+                steps:
+                  - step:
+                      type: BuildAndPushDockerRegistry
+                      name: Build and Push Image
+                      identifier: Build_and_Push_Image
+                      spec:
+                        connectorRef: mmmdockerhubwrite2
+                        repo: datarobotdev/datarobotopentelemetry
+                        tags:
+                          - ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
+                        dockerfile: ci.Dockerfile
+                        optimize: true
+                        remoteCacheRepo: datarobotdev/datarobotopentelemetry
+                        resources:
+                          limits:
+                            memory: 1Gi
+                            cpu: "1"
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  containerSecurityContext:
+                    privileged: false
+                  os: Linux
+              caching:
+                enabled: false
+                paths: []
+              slsa_provenance:
+                enabled: false
     - parallel:
         - stage:
             name: Linting
@@ -144,13 +184,7 @@ pipeline:
                           echo "Run License Check"
                           license-eye -v info -c .licenserc.yaml header check
               infrastructure:
-                type: KubernetesDirect
-                spec:
-                  connectorRef: account.cigeneral
-                  namespace: harness-delegate-ng
-                  automountServiceAccountToken: true
-                  nodeSelector: {}
-                  os: Linux
+                useFromStage: Build_Docker_Image
               caching:
                 enabled: false
                 paths: []


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the CI pipeline to build/push a Docker image and to reuse infrastructure across stages, which can break builds or publish incorrect images if misconfigured.
> 
> **Overview**
> Adds a new `Build_Docker_Image` stage to the Harness CI pipeline that builds and pushes `datarobotdev/datarobotopentelemetry` using `ci.Dockerfile`, tagging images with the short git hash from the earlier `Git_Hash` stage.
> 
> Updates the License Check stage to reuse infrastructure via `useFromStage: Build_Docker_Image` instead of defining its own KubernetesDirect infrastructure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b0fc56cf171fbf17708f97fc5357bbf15fb4a55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->