### PR TITLE
[MMM-22507] fix yaml format

### DIFF
--- a/.harness/CI.yaml
+++ b/.harness/CI.yaml
@@ -39,7 +39,7 @@ pipeline:
               automountServiceAccountToken: true
               nodeSelector: {}
               os: Linux
-                      - stage:
+    - stage:
             name: Build Docker Image CI
             identifier: Build_Docker_Image
             description: ""


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure YAML formatting/indentation change in the Harness CI pipeline definition; no functional code or runtime logic is modified.
> 
> **Overview**
> Fixes the YAML structure in `.harness/CI.yaml` by correcting the indentation/list formatting for the `Build Docker Image CI` stage so it is a proper `- stage:` entry under `stages`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2e0e7d151bc60bd40b97fb7a097802fa24d3695. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->