### PR TITLE
[MMM-22507] Add docker file for CI

### DIFF
--- a/.harness/CI.yaml
+++ b/.harness/CI.yaml
@@ -40,49 +40,49 @@ pipeline:
               nodeSelector: {}
               os: Linux
     - stage:
-            name: Build Docker Image CI
-            identifier: Build_Docker_Image
-            description: ""
-            type: CI
+        name: Build Docker Image CI
+        identifier: Build_Docker_Image
+        description: ""
+        type: CI
+        spec:
+          cloneCodebase: true
+          execution:
+            steps:
+              - step:
+                  type: BuildAndPushDockerRegistry
+                  name: Build and Push Image
+                  identifier: Build_and_Push_Image
+                  spec:
+                    connectorRef: mmmdockerhubwrite2
+                    repo: datarobotdev/datarobotopentelemetry
+                    tags:
+                      - ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
+                    dockerfile: ci.Dockerfile
+                    optimize: true
+                    remoteCacheRepo: datarobotdev/datarobotopentelemetry
+                    resources:
+                      limits:
+                        memory: 1Gi
+                        cpu: "1"
+          infrastructure:
+            type: KubernetesDirect
             spec:
-              cloneCodebase: true
-              execution:
-                steps:
-                  - step:
-                      type: BuildAndPushDockerRegistry
-                      name: Build and Push Image
-                      identifier: Build_and_Push_Image
-                      spec:
-                        connectorRef: mmmdockerhubwrite2
-                        repo: datarobotdev/datarobotopentelemetry
-                        tags:
-                          - ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
-                        dockerfile: ci.Dockerfile
-                        optimize: true
-                        remoteCacheRepo: datarobotdev/datarobotopentelemetry
-                        resources:
-                          limits:
-                            memory: 1Gi
-                            cpu: "1"
-              infrastructure:
-                type: KubernetesDirect
-                spec:
-                  connectorRef: account.cigeneral
-                  namespace: harness-delegate-ng
-                  automountServiceAccountToken: true
-                  nodeSelector: {}
-                  containerSecurityContext:
-                    privileged: false
-                  os: Linux
-              caching:
-                enabled: false
-                paths: []
-              slsa_provenance:
-                enabled: false
+              connectorRef: account.cigeneral
+              namespace: harness-delegate-ng
+              automountServiceAccountToken: true
+              nodeSelector: {}
+              containerSecurityContext:
+                privileged: false
+              os: Linux
+          caching:
+            enabled: false
+            paths: []
+          slsa_provenance:
+            enabled: false
     - parallel:
         - stage:
             name: Linting
-            identifier: CI
+            identifier: Linting
             type: CI
             spec:
               cloneCodebase: true

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,0 +1,26 @@
+FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.12-dev
+
+USER root
+
+ENV PIP_DEFAULT_TIMEOUT=100 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_ROOT_USER_ACTION=ignore \
+    PATH="/opt/datarobotopentelemetry/venv/bin:$PATH"
+
+# Install system dependencies
+# Install system dependencies
+RUN apk update && \
+    apk upgrade --no-cache && \
+    apk add ca-certificates git make shadow jq && \
+    python3.12 -m pip install --upgrade pip
+
+WORKDIR /opt/datarobotopentelemetry
+
+# Copy the actual app code
+COPY . .
+
+ENV RUFF_CACHE_DIR=/tmp
+USER nonroot
+
+ENTRYPOINT []


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI pipeline behavior by introducing a new `ci.Dockerfile`-based build/push step and adjusting stage identifiers, which can break builds or downstream stages if misconfigured.
> 
> **Overview**
> Adds a new `ci.Dockerfile` to build a dedicated CI image (Python 3.12 FIPS base, installs build tools, copies repo, runs as `nonroot`).
> 
> Updates `.harness/CI.yaml` to use this Dockerfile in the **Build Docker Image** stage and fixes pipeline YAML/stage metadata (notably renaming the `Linting` stage identifier from `CI` to `Linting`), ensuring subsequent steps run against the newly built `ci-<git-sha>` image.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 523d867b54a31028a9998eecdd063a2851541add. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->