### PR TITLE
[MMM-22507] dd

### DIFF
--- a/.harness/CI.yaml
+++ b/.harness/CI.yaml
@@ -53,7 +53,7 @@ pipeline:
                   name: Build and Push Image
                   identifier: Build_and_Push_Image
                   spec:
-                    connectorRef: mmmdockerhubwrite2
+                    connectorRef: org.mmmdockerhubwriteorg
                     repo: datarobotdev/datarobotopentelemetry
                     tags:
                       - ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -6,7 +6,6 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_ROOT_USER_ACTION=ignore \
-    PATH="/opt/datarobotopentelemetry/venv/bin:$PATH"
 
 # Install system dependencies
 # Install system dependencies


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only changes; could affect image build/push credentials and runtime PATH inside the CI image if the pipeline relies on the removed virtualenv path.
> 
> **Overview**
> Updates the Harness CI pipeline to use the org-level Docker registry write connector (`org.mmmdockerhubwriteorg`) for the build-and-push step.
> 
> Simplifies `ci.Dockerfile` by removing the `PATH` override that prepended a venv bin directory, leaving the rest of the CI image build unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b503c2f9b61015185b0fd5f5fc8b26eace86d0b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->