### PR TITLE
[MMM-22507] fix repo name

### DIFF
--- a/.harness/CI.yaml
+++ b/.harness/CI.yaml
@@ -54,12 +54,12 @@ pipeline:
                   identifier: Build_and_Push_Image
                   spec:
                     connectorRef: org.mmmdockerhubwriteorg
-                    repo: datarobotdev/datarobotopentelemetry
+                    repo: datarobotdev/datarobot-opentelemetry
                     tags:
                       - ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
                     dockerfile: ci.Dockerfile
                     optimize: true
-                    remoteCacheRepo: datarobotdev/datarobotopentelemetry
+                    remoteCacheRepo: datarobotdev/datarobot-opentelemetry
                     resources:
                       limits:
                         memory: 1Gi
@@ -103,7 +103,7 @@ pipeline:
                           identifier: Ruff_Linting
                           spec:
                             connectorRef: account.dockerhub_datarobot_read
-                            image: datarobotdev/datarobotopentelemetry:ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
+                            image: datarobotdev/datarobot-opentelemetry:ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
                             shell: Sh
                             command: |-
                               echo "TODO Add Ruff Linting"
@@ -144,7 +144,7 @@ pipeline:
                       identifier: Run_Unit_Test
                       spec:
                         connectorRef: account.dockerhub_datarobot_read
-                        image: datarobotdev/datarobotopentelemetry:ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
+                        image: datarobotdev/datarobot-opentelemetry:ci-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
                         shell: Sh
                         command: |-
                           echo "TODO Add Unit Test"


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI configuration change that only adjusts Docker repository references; main risk is build/lint/test steps failing if any remaining references still point to the old image name.
> 
> **Overview**
> Updates `.harness/CI.yaml` to reference the corrected Docker Hub repo `datarobotdev/datarobot-opentelemetry` for the build-and-push step (`repo`/`remoteCacheRepo`) and for CI job images (e.g., Ruff linting and unit tests) that consume the just-built `ci-<GIT_HASH_SHORT>` tag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cafada55db2cc88473a9dca30626c0c2310c515d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->