### PR TITLE
[MMM-22507] fix ci Docker file

### DIFF
--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -5,7 +5,7 @@ USER root
 ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
-    PIP_ROOT_USER_ACTION=ignore \
+    PIP_ROOT_USER_ACTION=ignore 
 
 # Install system dependencies
 # Install system dependencies


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Very small CI-only Dockerfile tweak that should only affect image build parsing/formatting; low risk aside from potential build behavior changes if the previous file was invalid.
> 
> **Overview**
> Fixes the `ENV` block in `ci.Dockerfile` by adjusting the line continuation/trailing character on `PIP_ROOT_USER_ACTION=ignore`, ensuring the Dockerfile parses as intended during CI image builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97c0c759fff0615ff870ee2904e2a454cd9f2e7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->