### PR TITLE
[MMM-22501] Add publish piplines

### DIFF
--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -13,7 +13,7 @@ pipeline:
   variables:
     - name: primaryBranchName
       type: String
-      description: Primary branch for conditional publishing (e.g., main)
+      description: Primary branch for conditional publishing
       required: true
       value: main
   stages:
@@ -25,20 +25,6 @@ pipeline:
           cloneCodebase: true
           execution:
             steps:
-              - step:
-                  type: Run
-                  name: Extract Package Info
-                  identifier: Extract_Package_Info
-                  spec:
-                    connectorRef: account.dockerhub_datarobot_read
-                    image: alpine/git
-                    shell: Sh
-                    command: |-
-                      cd python/datarobot-opentelemetry
-                      PACKAGE_NAME=$(grep '^name' pyproject.toml | head -1 | awk -F'"' '{print $2}')
-                      PACKAGE_VERSION=$(grep '^version' pyproject.toml | head -1 | awk -F'"' '{print $2}')
-                      echo "Package: ${PACKAGE_NAME}"
-                      echo "Version: ${PACKAGE_VERSION}"
               - step:
                   type: Run
                   name: Build Distribution
@@ -53,8 +39,8 @@ pipeline:
                       echo "Build complete. Artifacts:"
                       ls -lh dist/
                     envVariables:
-                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
-                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
               - step:
                   type: Run
                   name: Check Version Not Duplicate
@@ -87,8 +73,8 @@ pipeline:
                         echo "✓ Version ${PACKAGE_VERSION} is new, ready to publish"
                       fi
                     envVariables:
-                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
-                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
               - step:
                   type: Run
                   name: Publish to Artifactory
@@ -108,10 +94,10 @@ pipeline:
                         --publish-url "https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
                       echo "✓ Successfully published ${PACKAGE_NAME} v${PACKAGE_VERSION}"
                     envVariables:
-                      ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
-                      ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
-                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
-                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+                      ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
+                      ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>>
                   when:
                     stageStatus: Success
                     condition: <+pipeline.properties.ci.codebase.build.spec.branch> == <+pipeline.variables.primaryBranchName>
@@ -123,14 +109,4 @@ pipeline:
               automountServiceAccountToken: true
               nodeSelector: {}
               os: Linux
-          variables:
-            - name: ARTIFACTORY_USERNAME
-              type: String
-              description: Artifactory username for reading dependencies and publishing
-              required: true
-              value: <+input>
-            - name: ARTIFACTORY_PASSWORD
-              type: Secret
-              description: Artifactory password/token for reading dependencies and publishing
-              required: true
-              value: <+input>
+          variables: []

--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -101,6 +101,29 @@ pipeline:
                   when:
                     stageStatus: Success
                     condition: <+pipeline.properties.ci.codebase.build.spec.branch> == <+pipeline.variables.primaryBranchName>
+              - step:
+                  type: Run
+                  name: Create Git Tag
+                  identifier: Create_Git_Tag
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: alpine/git
+                    shell: Sh
+                    command: |-
+                      cd python/datarobot-opentelemetry
+                      PACKAGE_VERSION=$(grep '^version' pyproject.toml | head -1 | awk -F'"' '{print $2}')
+                      TAG_NAME="python-v${PACKAGE_VERSION}"
+                      
+                      echo "Creating git tag: ${TAG_NAME}"
+                      git tag -a "${TAG_NAME}" -m "Release version ${PACKAGE_VERSION}"
+                      git push https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/datarobot/datarobot-opentelemetry.git "${TAG_NAME}"
+                      echo "✓ Tagged and pushed ${TAG_NAME}"
+                    envVariables:
+                      GITHUB_USERNAME: svc-harness-git2
+                      GITHUB_PASSWORD: <+secrets.getValue("account.githubpatsvcharnessgit2")>
+                  when:
+                    stageStatus: Success
+                    condition: <+pipeline.properties.ci.codebase.build.spec.branch> == <+pipeline.variables.primaryBranchName>
           infrastructure:
             type: KubernetesDirect
             spec:

--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -97,7 +97,7 @@ pipeline:
                       ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
                       ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
                       UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
                   when:
                     stageStatus: Success
                     condition: <+pipeline.properties.ci.codebase.build.spec.branch> == <+pipeline.variables.primaryBranchName>

--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -1,0 +1,136 @@
+pipeline:
+  name: Publish
+  identifier: Publish
+  projectIdentifier: datarobotopentelemetry
+  orgIdentifier: MMM
+  tags: {}
+  properties:
+    ci:
+      codebase:
+        connectorRef: account.svc_harness_git1
+        repoName: datarobot-opentelemetry
+        build: <+input>
+  variables:
+    - name: primaryBranchName
+      type: String
+      description: Primary branch for conditional publishing (e.g., main)
+      required: true
+      value: main
+  stages:
+    - stage:
+        name: Build and Publish
+        identifier: Build_and_Publish
+        type: CI
+        spec:
+          cloneCodebase: true
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Extract Package Info
+                  identifier: Extract_Package_Info
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: alpine/git
+                    shell: Sh
+                    command: |-
+                      cd python/datarobot-opentelemetry
+                      PACKAGE_NAME=$(grep '^name' pyproject.toml | head -1 | awk -F'"' '{print $2}')
+                      PACKAGE_VERSION=$(grep '^version' pyproject.toml | head -1 | awk -F'"' '{print $2}')
+                      echo "Package: ${PACKAGE_NAME}"
+                      echo "Version: ${PACKAGE_VERSION}"
+              - step:
+                  type: Run
+                  name: Build Distribution
+                  identifier: Build_Distribution
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: ghcr.io/astral-sh/uv:latest
+                    shell: Sh
+                    command: |-
+                      cd python/datarobot-opentelemetry
+                      uv build
+                      echo "Build complete. Artifacts:"
+                      ls -lh dist/
+                    envVariables:
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+              - step:
+                  type: Run
+                  name: Check Version Not Duplicate
+                  identifier: Check_Version_Not_Duplicate
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: ghcr.io/astral-sh/uv:latest
+                    shell: Sh
+                    command: |-
+                      cd python/datarobot-opentelemetry
+                      PACKAGE_NAME=$(grep '^name' pyproject.toml | head -1 | awk -F'"' '{print $2}')
+                      PACKAGE_VERSION=$(grep '^version' pyproject.toml | head -1 | awk -F'"' '{print $2}')
+                      
+                      echo "Checking if ${PACKAGE_NAME}==${PACKAGE_VERSION} already exists in Artifactory..."
+                      
+                      # Create a separate venv for the check (don't use local install)
+                      uv venv .test_pkg_pull_venv
+                      source .test_pkg_pull_venv/bin/activate
+                      set +e
+                      uv pip install "${PACKAGE_NAME}==${PACKAGE_VERSION}" --dry-run
+                      EXIT_CODE=$?
+                      set -e
+                      deactivate
+                      
+                      if [ $EXIT_CODE -eq 0 ]; then
+                        echo "⚠️  Version ${PACKAGE_VERSION} already exists in Artifactory"
+                        echo "Skipping publish to avoid duplicate"
+                        exit 1
+                      else
+                        echo "✓ Version ${PACKAGE_VERSION} is new, ready to publish"
+                      fi
+                    envVariables:
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+              - step:
+                  type: Run
+                  name: Publish to Artifactory
+                  identifier: Publish_to_Artifactory
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: ghcr.io/astral-sh/uv:latest
+                    shell: Sh
+                    command: |-
+                      cd python/datarobot-opentelemetry
+                      PACKAGE_NAME=$(grep '^name' pyproject.toml | head -1 | awk -F'"' '{print $2}')
+                      PACKAGE_VERSION=$(grep '^version' pyproject.toml | head -1 | awk -F'"' '{print $2}')
+                      
+                      echo "Publishing ${PACKAGE_NAME} v${PACKAGE_VERSION} to Artifactory..."
+                      uv publish \
+                        --check-url "https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
+                        --publish-url "https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
+                      echo "✓ Successfully published ${PACKAGE_NAME} v${PACKAGE_VERSION}"
+                    envVariables:
+                      ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+                      ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+                  when:
+                    stageStatus: Success
+                    condition: <+pipeline.properties.ci.codebase.build.spec.branch> == <+pipeline.variables.primaryBranchName>
+          infrastructure:
+            type: KubernetesDirect
+            spec:
+              connectorRef: account.cigeneral
+              namespace: harness-delegate-ng
+              automountServiceAccountToken: true
+              nodeSelector: {}
+              os: Linux
+          variables:
+            - name: ARTIFACTORY_USERNAME
+              type: String
+              description: Artifactory username for reading dependencies and publishing
+              required: true
+              value: <+input>
+            - name: ARTIFACTORY_PASSWORD
+              type: Secret
+              description: Artifactory password/token for reading dependencies and publishing
+              required: true
+              value: <+input>

--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -56,8 +56,10 @@ pipeline:
                       
                       echo "Publishing ${PACKAGE_NAME} v${PACKAGE_VERSION} to Artifactory..."
                       uv publish \
-                        --check-url "https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
-                        --publish-url "https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
+                        --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
+                        --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev" \
+                        --username "${ARTIFACTORY_USERNAME}" \
+                        --password "${ARTIFACTORY_PASSWORD}"
                       echo "✓ Successfully published ${PACKAGE_NAME} v${PACKAGE_VERSION}"
                     envVariables:
                       ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
@@ -82,7 +84,19 @@ pipeline:
                       
                       echo "Creating git tag: ${TAG_NAME}"
                       git tag -a "${TAG_NAME}" -m "Release version ${PACKAGE_VERSION}"
-                      git push https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/datarobot/datarobot-opentelemetry.git "${TAG_NAME}"
+
+                      cat <<'EOF' >/tmp/git-askpass.sh
+                      #!/bin/sh
+                      case "$1" in
+                        *Username*) echo "$GITHUB_USERNAME" ;;
+                        *Password*) echo "$GITHUB_PASSWORD" ;;
+                      esac
+                      EOF
+                      chmod 700 /tmp/git-askpass.sh
+
+                      GIT_ASKPASS=/tmp/git-askpass.sh GIT_TERMINAL_PROMPT=0 \
+                        git push https://github.com/datarobot/datarobot-opentelemetry.git "${TAG_NAME}"
+                      rm -f /tmp/git-askpass.sh
                       echo "✓ Tagged and pushed ${TAG_NAME}"
                     envVariables:
                       GITHUB_USERNAME: svc-harness-git2

--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -43,40 +43,6 @@ pipeline:
                       UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
               - step:
                   type: Run
-                  name: Check Version Not Duplicate
-                  identifier: Check_Version_Not_Duplicate
-                  spec:
-                    connectorRef: account.dockerhub_datarobot_read
-                    image: ghcr.io/astral-sh/uv:latest
-                    shell: Sh
-                    command: |-
-                      cd python/datarobot-opentelemetry
-                      PACKAGE_NAME=$(grep '^name' pyproject.toml | head -1 | awk -F'"' '{print $2}')
-                      PACKAGE_VERSION=$(grep '^version' pyproject.toml | head -1 | awk -F'"' '{print $2}')
-                      
-                      echo "Checking if ${PACKAGE_NAME}==${PACKAGE_VERSION} already exists in Artifactory..."
-                      
-                      # Create a separate venv for the check (don't use local install)
-                      uv venv .test_pkg_pull_venv
-                      source .test_pkg_pull_venv/bin/activate
-                      set +e
-                      uv pip install "${PACKAGE_NAME}==${PACKAGE_VERSION}" --dry-run
-                      EXIT_CODE=$?
-                      set -e
-                      deactivate
-                      
-                      if [ $EXIT_CODE -eq 0 ]; then
-                        echo "⚠️  Version ${PACKAGE_VERSION} already exists in Artifactory"
-                        echo "Skipping publish to avoid duplicate"
-                        exit 1
-                      else
-                        echo "✓ Version ${PACKAGE_VERSION} is new, ready to publish"
-                      fi
-                    envVariables:
-                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
-              - step:
-                  type: Run
                   name: Publish to Artifactory
                   identifier: Publish_to_Artifactory
                   spec:

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -115,8 +115,10 @@ template:
 
                         echo "Publishing ${PACKAGE_NAME} ${DEV_VERSION} to Artifactory..."
                         uv publish \
-                          --check-url "https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
-                          --publish-url "https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
+                          --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
+                          --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev" \
+                          --username "${ARTIFACTORY_USERNAME}" \
+                          --password "${ARTIFACTORY_PASSWORD}"
                         echo "✓ Published ${DEV_VERSION}"
                       envVariables:
                         ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -52,8 +52,8 @@ template:
                         uv run python3 --version
                         uv sync --extra dev
                       envVariables:
-                        UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
-                        UV_INDEX_DR_ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+                        UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                        UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
                 - parallel:
                     - step:
                         type: Run
@@ -122,10 +122,10 @@ template:
                         BUILD_TYPE: <+pipeline.properties.ci.codebase.build.type>
                         BUILD_BRANCH: <+pipeline.properties.ci.codebase.build.spec.branch>
                         BUILD_NUMBER: <+pipeline.properties.ci.codebase.build.spec.number>
-                        ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
-                        ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
-                        UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
-                        UV_INDEX_DR_ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+                        ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
+                        ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                        UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                        UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
                     description: Builds and publishes a dev version with the commit hash appended (e.g. 1.2.3.dev0+abc1234) to Artifactory on every primary branch merge.
                     when:
                       stageStatus: Success
@@ -136,19 +136,9 @@ template:
               description: The python version to use, e.g. 3.10, 3.11, 3.12
               required: true
               value: "3.12"
-            - name: ARTIFACTORY_USERNAME
-              type: String
-              description: The username to use for artifactory, used to both read and write
-              required: false
-              value: <+input>
-            - name: ARTIFACTORY_PASSWORD
-              type: Secret
-              description: The password to use for artifactory, used to both read and write
-              required: true
-              value: <+input>
     variables:
       - name: primaryBranchName
         type: String
         description: The name of the primary branch for the repo (e.g. master or main). Is used to determine whether the pipeline is running on the primary branch, which is used to determine whether or not the pipeline should attempt to publish.
         required: true
-        value: <+input>
+        value: main

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -1,0 +1,154 @@
+template:
+  name: Publish dev version to Artifactory
+  identifier: Publish_dev
+  versionLabel: dev
+  type: Pipeline
+  description: A full-featured test-and-publish pipeline built around uv and ruff (and pytest).
+  tags: {}
+  spec:
+    properties:
+      ci:
+        codebase:
+          connectorRef: account.svc_harness_git1
+          repoName: <+input>
+          build: <+input>
+    stages:
+      - stage:
+          name: Run Tests and Publish
+          identifier: Run_Tests_and_Publish
+          description: ""
+          type: CI
+          spec:
+            cloneCodebase: true
+            caching:
+              enabled: false
+              override: false
+              paths: []
+            buildIntelligence:
+              enabled: false
+            platform:
+              os: Linux
+              arch: Amd64
+            runtime:
+              type: Cloud
+              spec: {}
+            execution:
+              steps:
+                - step:
+                    type: Run
+                    name: Install Dependencies
+                    identifier: Initialize
+                    description: Prepare the environment
+                    spec:
+                      shell: Bash
+                      command: |-
+                        curl -LsSf https://astral.sh/uv/install.sh | sh
+
+                        cd python/datarobot-opentelemetry
+
+                        uv python install <+stage.variables.pythonVersion>
+                        uv venv -p <+stage.variables.pythonVersion> .venv
+                        source .venv/bin/activate
+                        uv run python3 --version
+                        uv sync --extra dev
+                      envVariables:
+                        UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
+                        UV_INDEX_DR_ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+                - parallel:
+                    - step:
+                        type: Run
+                        name: Run Tests
+                        identifier: Run_Tests
+                        spec:
+                          shell: Bash
+                          command: |-
+                            cd python/datarobot-opentelemetry
+                            source .venv/bin/activate
+                            uv run python3 -m pytest tests/ --junit-xml test-results.xml
+                          reports:
+                            type: JUnit
+                            spec:
+                              paths:
+                                - python/datarobot-opentelemetry/test-results.xml
+                    - step:
+                        type: Run
+                        name: Run Formatter Check
+                        identifier: Run_Formatter_Check
+                        spec:
+                          shell: Bash
+                          command: |-
+                            cd python/datarobot-opentelemetry
+                            uv run ruff format --check
+                    - step:
+                        type: Run
+                        name: Run Linter Check
+                        identifier: Run_Linter_Check
+                        spec:
+                          shell: Bash
+                          command: |-
+                            cd python/datarobot-opentelemetry
+                            uv run ruff check
+                - step:
+                    type: Run
+                    name: Publish Dev Version
+                    identifier: Maybe_Publish
+                    spec:
+                      shell: Bash
+                      command: |-
+                        cd python/datarobot-opentelemetry
+
+                        export PACKAGE_NAME=$(uv version | awk '{print $1}')
+                        export BASE_VERSION=$(uv version --short)
+                        export COMMIT_HASH=$(git rev-parse --short HEAD)
+                        export DEV_VERSION="${BASE_VERSION}.dev0+${COMMIT_HASH}"
+
+                        echo "Package:      ${PACKAGE_NAME}"
+                        echo "Base version: ${BASE_VERSION}"
+                        echo "Dev version:  ${DEV_VERSION}"
+
+                        # Stamp the dev version into pyproject.toml before building
+                        sed -i "s/^version = \"${BASE_VERSION}\"/version = \"${DEV_VERSION}\"/" pyproject.toml
+
+                        # n.b. `uv build` uses a separate compartmentalized environment to build
+                        # which is why we have to inject UV_INDEX_DR_ARTIFACTORY credentials
+                        uv build
+
+                        echo "Publishing ${PACKAGE_NAME} ${DEV_VERSION} to Artifactory..."
+                        uv publish \
+                          --check-url "https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
+                          --publish-url "https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
+                        echo "✓ Published ${DEV_VERSION}"
+                      envVariables:
+                        BUILD_TYPE: <+pipeline.properties.ci.codebase.build.type>
+                        BUILD_BRANCH: <+pipeline.properties.ci.codebase.build.spec.branch>
+                        BUILD_NUMBER: <+pipeline.properties.ci.codebase.build.spec.number>
+                        ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+                        ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
+                        UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+stage.variables.ARTIFACTORY_PASSWORD>
+                        UV_INDEX_DR_ARTIFACTORY_USERNAME: <+stage.variables.ARTIFACTORY_USERNAME>
+                    description: Builds and publishes a dev version with the commit hash appended (e.g. 1.2.3.dev0+abc1234) to Artifactory on every primary branch merge.
+                    when:
+                      stageStatus: Success
+                      condition: <+pipeline.properties.ci.codebase.build.spec.branch> == <+pipeline.variables.primaryBranchName>
+          variables:
+            - name: pythonVersion
+              type: String
+              description: The python version to use, e.g. 3.10, 3.11, 3.12
+              required: true
+              value: "3.12"
+            - name: ARTIFACTORY_USERNAME
+              type: String
+              description: The username to use for artifactory, used to both read and write
+              required: false
+              value: <+input>
+            - name: ARTIFACTORY_PASSWORD
+              type: Secret
+              description: The password to use for artifactory, used to both read and write
+              required: true
+              value: <+input>
+    variables:
+      - name: primaryBranchName
+        type: String
+        description: The name of the primary branch for the repo (e.g. master or main). Is used to determine whether the pipeline is running on the primary branch, which is used to determine whether or not the pipeline should attempt to publish.
+        required: true
+        value: <+input>

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -50,7 +50,7 @@ template:
                         uv venv -p <+stage.variables.pythonVersion> .venv
                         source .venv/bin/activate
                         uv run python3 --version
-                        uv sync --extra dev
+                        uv sync --group dev
                       envVariables:
                         UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
                         UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -119,9 +119,6 @@ template:
                           --publish-url "https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
                         echo "✓ Published ${DEV_VERSION}"
                       envVariables:
-                        BUILD_TYPE: <+pipeline.properties.ci.codebase.build.type>
-                        BUILD_BRANCH: <+pipeline.properties.ci.codebase.build.spec.branch>
-                        BUILD_NUMBER: <+pipeline.properties.ci.codebase.build.spec.number>
                         ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
                         ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
                         UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>

--- a/ci-python.Dockerfile
+++ b/ci-python.Dockerfile
@@ -9,8 +9,7 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
     PATH="/opt/app/.venv/bin:$PATH" \
     UV_NO_CACHE=1 \
     UV_PROJECT_ENVIRONMENT="/opt/app/.venv" \
-    APP_VERSION="0.0.1" \
-    APP_COMMIT_HASH_SHORT="EEEEEE"
+    APP_VERSION="0.0.1"
 
 # Install system dependencies
 RUN apk update && \
@@ -26,8 +25,6 @@ COPY python/datarobot-opentelemetry .
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN git config --global --add safe.directory /opt/app && \
     uv version -- $APP_VERSION && \
-    sed -i "s/0.0.0/$APP_VERSION/g" src/datarobot_opentelemetry/__init__.py && \
-    sed -i "s/FFFFFFF/$APP_COMMIT_HASH_SHORT/g" src/datarobot_opentelemetry/__init__.py && \
     uv sync --frozen --no-cache
 
 ENV RUFF_CACHE_DIR=/tmp

--- a/python/datarobot-opentelemetry/README.md
+++ b/python/datarobot-opentelemetry/README.md
@@ -1,0 +1,39 @@
+# datarobot-opentelemetry
+
+OpenTelemetry semantic conventions and utilities for DataRobot telemetry integration.
+
+## Installation
+
+```bash
+pip install datarobot-opentelemetry
+```
+
+## Usage
+
+```python
+from datarobot_opentelemetry.semconv import SpanAttributes
+
+# Use constants as span attribute keys
+span.set_attribute(SpanAttributes.GEN_AI_REQUEST_MODEL, "gpt-4o")
+span.set_attribute(SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS, 128)
+span.set_attribute(SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS, 64)
+
+# DataRobot-specific attributes
+span.set_attribute(SpanAttributes.DATAROBOT_TRACE_NAME, "my-agent-trace")
+span.set_attribute(SpanAttributes.DATAROBOT_SESSION_ID, session_id)
+```
+
+### Available attribute groups
+
+| Group | Prefix | Description |
+|---|---|---|
+| Gen AI standard | `gen_ai.*` | OpenTelemetry Gen AI semantic conventions |
+| Server | `server.*` | Server address/port |
+| Error | `error.*` | Error type |
+| DataRobot | `datarobot.*` | DataRobot-specific trace metadata |
+
+All constants live in `datarobot_opentelemetry.semconv.SpanAttributes`.
+
+## Requirements
+
+- Python 3.12+

--- a/python/datarobot-opentelemetry/pyproject.toml
+++ b/python/datarobot-opentelemetry/pyproject.toml
@@ -3,11 +3,23 @@ name = "datarobot-opentelemetry"
 version = "0.1.0"
 description = "OpenTelemetry utilities and encapsulation of semantic naming conventions for improved integration with DataRobot."
 readme = "README.md"
+license = { text = "Proprietary" }
 authors = [
     { name = "DataRobot", email = "support@datarobot.com" }
 ]
 requires-python = ">=3.12"
 dependencies = []
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/datarobot/datarobot-opentelemetry"
+Repository = "https://github.com/datarobot/datarobot-opentelemetry"
 
 [build-system]
 requires = ["hatchling"]

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/__init__.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/__init__.py
@@ -1,4 +1,10 @@
-__version__ = "0.0.0"  # do not change this on local, gets templated in automation
-__commit_hash_short__ = (
-    "FFFFFFF"  # do not change this on local, gets templated in automation
-)
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("datarobot-opentelemetry")
+except PackageNotFoundError:
+    __version__ = "0.0.0"  # package not installed
+
+from datarobot_opentelemetry.semconv import SpanAttributes
+
+__all__ = ["SpanAttributes", "__version__"]

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/semconv/traces.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/semconv/traces.py
@@ -16,7 +16,7 @@ from typing import Final
 class SpanAttributes:
     """Constants for span attribute keys used in Gen AI telemetry."""
 
-    # Attrribute keys from open-telemetry specification:
+    # Attribute keys from open-telemetry specification:
     # https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/
     GEN_AI_PROVIDER_NAME: Final = "gen_ai.provider.name"
     GEN_AI_OPERATION_NAME: Final = "gen_ai.operation.name"
@@ -60,10 +60,6 @@ class SpanAttributes:
     )
     GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS: Final = "gen_ai.usage.cache_read.input_tokens"
 
-    # Derived attributes
-    GEN_AI_USAGE_TOTAL_TOKENS: Final = "gen_ai.usage.total_tokens"
-    GEN_AI_USAGE_COST: Final = "gen_ai.usage.cost"
-
     # DataRobot specific attributes
     DATAROBOT_TRACE_NAME: Final = "datarobot.trace_name"
     DATAROBOT_USER_ID: Final = "datarobot.user_id"
@@ -77,3 +73,4 @@ class SpanAttributes:
     DATAROBOT_GUARDRAILS_TRIGGERED: Final = "datarobot.guardrails.triggered"
     DATAROBOT_GUARDRAILS_LABELS: Final = "datarobot.guardrails.labels"
     DATAROBOT_GUARDRAILS_ACTIONS: Final = "datarobot.guardrails.actions"
+    DATAROBOT_MODERATION_COST: Final = "datarobot.moderation.cost"

--- a/python/datarobot-opentelemetry/tests/unit/test_smoke.py
+++ b/python/datarobot-opentelemetry/tests/unit/test_smoke.py
@@ -11,5 +11,34 @@
 # publication of such source code.
 
 
-def test_unit_smoke() -> None:
-    assert True
+from datarobot_opentelemetry.semconv import SpanAttributes
+from datarobot_opentelemetry import SpanAttributes as TopLevelSpanAttributes
+
+
+def test_span_attributes_importable() -> None:
+    assert SpanAttributes is TopLevelSpanAttributes
+
+
+def test_gen_ai_standard_attributes() -> None:
+    assert SpanAttributes.GEN_AI_REQUEST_MODEL == "gen_ai.request.model"
+    assert SpanAttributes.GEN_AI_RESPONSE_MODEL == "gen_ai.response.model"
+    assert SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS == "gen_ai.usage.input_tokens"
+    assert SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS == "gen_ai.usage.output_tokens"
+
+
+def test_datarobot_specific_attributes() -> None:
+    assert SpanAttributes.DATAROBOT_TRACE_NAME == "datarobot.trace_name"
+    assert SpanAttributes.DATAROBOT_SESSION_ID == "datarobot.session_id"
+    assert SpanAttributes.DATAROBOT_USER_ID == "datarobot.user_id"
+    assert SpanAttributes.DATAROBOT_TURN_ID == "datarobot.turn_id"
+
+
+def test_all_attribute_values_are_strings() -> None:
+    attrs = {
+        k: v
+        for k, v in vars(SpanAttributes).items()
+        if not k.startswith("_")
+    }
+    assert attrs, "SpanAttributes should have at least one constant"
+    for name, value in attrs.items():
+        assert isinstance(value, str), f"{name} should be a string, got {type(value)}"


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automated publishing and git-tagging workflows plus changes Python package version handling, which could impact release behavior if misconfigured. No runtime business logic changes beyond packaging metadata/constants.
> 
> **Overview**
> Adds two Harness CI pipelines: a `Publish` pipeline that builds the Python distribution, publishes to Artifactory, and creates/pushes a `python-v<version>` git tag (only on the primary branch), and a `Publish_dev` template that runs `pytest`/`ruff` then publishes a commit-hash-stamped dev version.
> 
> Updates packaging/build details: `ci-python.Dockerfile` stops templating commit/version into `__init__.py`, `datarobot_opentelemetry.__init__` now derives `__version__` from installed metadata and re-exports `SpanAttributes`, `pyproject.toml` gains license/classifiers/URLs, `SpanAttributes` drops derived token/cost constants and adds `DATAROBOT_MODERATION_COST`, and smoke tests/README are expanded to validate imports and key constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5f7344982a74564324823aca87742d86046743d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->