### PR TITLE
[MMM-22501] Tnek/mmm 22501 2

### DIFF
--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -42,9 +42,6 @@ pipeline:
                       uv build
                       echo "Build complete. Artifacts:"
                       ls -lh dist/
-                    envVariables:
-                      UV_PUBLISH_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_PUBLISH_USERNAME: <+variable.account.artifactory_username>
               - step:
                   type: Run
                   name: Publish to Artifactory

--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -31,9 +31,13 @@ pipeline:
                   identifier: Build_Distribution
                   spec:
                     connectorRef: account.dockerhub_datarobot_read
-                    image: ghcr.io/astral-sh/uv:latest
-                    shell: Sh
+                    image: python:3.12-slim
+                    shell: Bash
                     command: |-
+                      set -euo pipefail
+                      curl -LsSf https://astral.sh/uv/install.sh | sh
+                      export PATH="${HOME}/.local/bin:${PATH}"
+
                       cd python/datarobot-opentelemetry
                       uv build
                       echo "Build complete. Artifacts:"
@@ -47,9 +51,13 @@ pipeline:
                   identifier: Publish_to_Artifactory
                   spec:
                     connectorRef: account.dockerhub_datarobot_read
-                    image: ghcr.io/astral-sh/uv:latest
-                    shell: Sh
+                    image: python:3.12-slim
+                    shell: Bash
                     command: |-
+                      set -euo pipefail
+                      curl -LsSf https://astral.sh/uv/install.sh | sh
+                      export PATH="${HOME}/.local/bin:${PATH}"
+
                       cd python/datarobot-opentelemetry
                       PACKAGE_NAME=$(grep '^name' pyproject.toml | head -1 | awk -F'"' '{print $2}')
                       PACKAGE_VERSION=$(grep '^version' pyproject.toml | head -1 | awk -F'"' '{print $2}')

--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -43,8 +43,8 @@ pipeline:
                       echo "Build complete. Artifacts:"
                       ls -lh dist/
                     envVariables:
-                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
+                      UV_PUBLISH_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_PUBLISH_USERNAME: <+variable.account.artifactory_username>
               - step:
                   type: Run
                   name: Publish to Artifactory
@@ -65,15 +65,11 @@ pipeline:
                       echo "Publishing ${PACKAGE_NAME} v${PACKAGE_VERSION} to Artifactory..."
                       uv publish \
                         --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
-                        --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev" \
-                        --username "${ARTIFACTORY_USERNAME}" \
-                        --password "${ARTIFACTORY_PASSWORD}"
+                        --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
                       echo "✓ Successfully published ${PACKAGE_NAME} v${PACKAGE_VERSION}"
                     envVariables:
-                      ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
-                      ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
+                      UV_PUBLISH_USERNAME: <+variable.account.artifactory_username>
+                      UV_PUBLISH_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
                   when:
                     stageStatus: Success
                     condition: <+pipeline.properties.ci.codebase.build.spec.branch> == <+pipeline.variables.primaryBranchName>

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -50,9 +50,6 @@ pipeline:
                       source .venv/bin/activate
                       uv run python3 --version
                       uv sync --group dev
-                    envVariables:
-                      UV_PUBLISH_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_PUBLISH_USERNAME: <+variable.account.artifactory_username>
               - parallel:
                   - step:
                       type: Run

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -51,8 +51,8 @@ pipeline:
                       uv run python3 --version
                       uv sync --group dev
                     envVariables:
-                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
+                      UV_PUBLISH_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_PUBLISH_USERNAME: <+variable.account.artifactory_username>
               - parallel:
                   - step:
                       type: Run
@@ -94,6 +94,8 @@ pipeline:
                   spec:
                     shell: Bash
                     command: |-
+                      set -euo pipefail
+
                       cd python/datarobot-opentelemetry
 
                       export PACKAGE_NAME=$(uv version | awk '{print $1}')
@@ -113,17 +115,15 @@ pipeline:
                       uv build
 
                       echo "Publishing ${PACKAGE_NAME} ${DEV_VERSION} to Artifactory..."
+                      # Prevent secret expansion from being printed if xtrace is enabled upstream.
+                      set +x
                       uv publish \
                         --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
-                        --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev" \
-                        --username "${ARTIFACTORY_USERNAME}" \
-                        --password "${ARTIFACTORY_PASSWORD}"
+                        --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
                       echo "✓ Published ${DEV_VERSION}"
                     envVariables:
-                      ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
-                      ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
+                      UV_PUBLISH_USERNAME: <+variable.account.artifactory_username>
+                      UV_PUBLISH_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
                   description: Builds and publishes a dev version with the commit hash appended (e.g. 1.2.3.dev0+abc1234) to Artifactory on every primary branch merge.
                   when:
                     stageStatus: Success

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -1,143 +1,142 @@
-template:
+pipeline:
   name: Publish dev version to Artifactory
   identifier: Publish_dev
-  versionLabel: dev
-  type: Pipeline
+  projectIdentifier: datarobotopentelemetry
+  orgIdentifier: MMM
   description: A full-featured test-and-publish pipeline built around uv and ruff (and pytest).
   tags: {}
-  spec:
-    properties:
-      ci:
-        codebase:
-          connectorRef: account.svc_harness_git1
-          repoName: <+input>
-          build: <+input>
-    stages:
-      - stage:
-          name: Run Tests and Publish
-          identifier: Run_Tests_and_Publish
-          description: ""
-          type: CI
-          spec:
-            cloneCodebase: true
-            caching:
-              enabled: false
-              override: false
-              paths: []
-            buildIntelligence:
-              enabled: false
-            platform:
-              os: Linux
-              arch: Amd64
-            runtime:
-              type: Cloud
-              spec: {}
-            execution:
-              steps:
-                - step:
-                    type: Run
-                    name: Install Dependencies
-                    identifier: Initialize
-                    description: Prepare the environment
-                    spec:
-                      shell: Bash
-                      command: |-
-                        curl -LsSf https://astral.sh/uv/install.sh | sh
+  properties:
+    ci:
+      codebase:
+        connectorRef: account.svc_harness_git1
+        repoName: <+input>
+        build: <+input>
+  stages:
+    - stage:
+        name: Run Tests and Publish
+        identifier: Run_Tests_and_Publish
+        description: ""
+        type: CI
+        spec:
+          cloneCodebase: true
+          caching:
+            enabled: false
+            override: false
+            paths: []
+          buildIntelligence:
+            enabled: false
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Install Dependencies
+                  identifier: Initialize
+                  description: Prepare the environment
+                  spec:
+                    shell: Bash
+                    command: |-
+                      curl -LsSf https://astral.sh/uv/install.sh | sh
 
-                        cd python/datarobot-opentelemetry
+                      cd python/datarobot-opentelemetry
 
-                        uv python install <+stage.variables.pythonVersion>
-                        uv venv -p <+stage.variables.pythonVersion> .venv
-                        source .venv/bin/activate
-                        uv run python3 --version
-                        uv sync --group dev
-                      envVariables:
-                        UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                        UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
-                - parallel:
-                    - step:
-                        type: Run
-                        name: Run Tests
-                        identifier: Run_Tests
-                        spec:
-                          shell: Bash
-                          command: |-
-                            cd python/datarobot-opentelemetry
-                            source .venv/bin/activate
-                            uv run python3 -m pytest tests/ --junit-xml test-results.xml
-                          reports:
-                            type: JUnit
-                            spec:
-                              paths:
-                                - python/datarobot-opentelemetry/test-results.xml
-                    - step:
-                        type: Run
-                        name: Run Formatter Check
-                        identifier: Run_Formatter_Check
-                        spec:
-                          shell: Bash
-                          command: |-
-                            cd python/datarobot-opentelemetry
-                            uv run ruff format --check
-                    - step:
-                        type: Run
-                        name: Run Linter Check
-                        identifier: Run_Linter_Check
-                        spec:
-                          shell: Bash
-                          command: |-
-                            cd python/datarobot-opentelemetry
-                            uv run ruff check
-                - step:
-                    type: Run
-                    name: Publish Dev Version
-                    identifier: Maybe_Publish
-                    spec:
-                      shell: Bash
-                      command: |-
-                        cd python/datarobot-opentelemetry
+                      uv python install <+stage.variables.pythonVersion>
+                      uv venv -p <+stage.variables.pythonVersion> .venv
+                      source .venv/bin/activate
+                      uv run python3 --version
+                      uv sync --group dev
+                    envVariables:
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
+              - parallel:
+                  - step:
+                      type: Run
+                      name: Run Tests
+                      identifier: Run_Tests
+                      spec:
+                        shell: Bash
+                        command: |-
+                          cd python/datarobot-opentelemetry
+                          source .venv/bin/activate
+                          uv run python3 -m pytest tests/ --junit-xml test-results.xml
+                        reports:
+                          type: JUnit
+                          spec:
+                            paths:
+                              - python/datarobot-opentelemetry/test-results.xml
+                  - step:
+                      type: Run
+                      name: Run Formatter Check
+                      identifier: Run_Formatter_Check
+                      spec:
+                        shell: Bash
+                        command: |-
+                          cd python/datarobot-opentelemetry
+                          uv run ruff format --check
+                  - step:
+                      type: Run
+                      name: Run Linter Check
+                      identifier: Run_Linter_Check
+                      spec:
+                        shell: Bash
+                        command: |-
+                          cd python/datarobot-opentelemetry
+                          uv run ruff check
+              - step:
+                  type: Run
+                  name: Publish Dev Version
+                  identifier: Maybe_Publish
+                  spec:
+                    shell: Bash
+                    command: |-
+                      cd python/datarobot-opentelemetry
 
-                        export PACKAGE_NAME=$(uv version | awk '{print $1}')
-                        export BASE_VERSION=$(uv version --short)
-                        export COMMIT_HASH=$(git rev-parse --short HEAD)
-                        export DEV_VERSION="${BASE_VERSION}.dev0+${COMMIT_HASH}"
+                      export PACKAGE_NAME=$(uv version | awk '{print $1}')
+                      export BASE_VERSION=$(uv version --short)
+                      export COMMIT_HASH=$(git rev-parse --short HEAD)
+                      export DEV_VERSION="${BASE_VERSION}.dev0+${COMMIT_HASH}"
 
-                        echo "Package:      ${PACKAGE_NAME}"
-                        echo "Base version: ${BASE_VERSION}"
-                        echo "Dev version:  ${DEV_VERSION}"
+                      echo "Package:      ${PACKAGE_NAME}"
+                      echo "Base version: ${BASE_VERSION}"
+                      echo "Dev version:  ${DEV_VERSION}"
 
-                        # Stamp the dev version into pyproject.toml before building
-                        sed -i "s/^version = \"${BASE_VERSION}\"/version = \"${DEV_VERSION}\"/" pyproject.toml
+                      # Stamp the dev version into pyproject.toml before building
+                      sed -i "s/^version = \"${BASE_VERSION}\"/version = \"${DEV_VERSION}\"/" pyproject.toml
 
-                        # n.b. `uv build` uses a separate compartmentalized environment to build
-                        # which is why we have to inject UV_INDEX_DR_ARTIFACTORY credentials
-                        uv build
+                      # n.b. `uv build` uses a separate compartmentalized environment to build
+                      # which is why we have to inject UV_INDEX_DR_ARTIFACTORY credentials
+                      uv build
 
-                        echo "Publishing ${PACKAGE_NAME} ${DEV_VERSION} to Artifactory..."
-                        uv publish \
-                          --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
-                          --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev" \
-                          --username "${ARTIFACTORY_USERNAME}" \
-                          --password "${ARTIFACTORY_PASSWORD}"
-                        echo "✓ Published ${DEV_VERSION}"
-                      envVariables:
-                        ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
-                        ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                        UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                        UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
-                    description: Builds and publishes a dev version with the commit hash appended (e.g. 1.2.3.dev0+abc1234) to Artifactory on every primary branch merge.
-                    when:
-                      stageStatus: Success
-                      condition: <+pipeline.properties.ci.codebase.build.spec.branch> == <+pipeline.variables.primaryBranchName>
-          variables:
-            - name: pythonVersion
-              type: String
-              description: The python version to use, e.g. 3.10, 3.11, 3.12
-              required: true
-              value: "3.12"
-    variables:
-      - name: primaryBranchName
-        type: String
-        description: The name of the primary branch for the repo (e.g. master or main). Is used to determine whether the pipeline is running on the primary branch, which is used to determine whether or not the pipeline should attempt to publish.
-        required: true
-        value: main
+                      echo "Publishing ${PACKAGE_NAME} ${DEV_VERSION} to Artifactory..."
+                      uv publish \
+                        --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
+                        --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev" \
+                        --username "${ARTIFACTORY_USERNAME}" \
+                        --password "${ARTIFACTORY_PASSWORD}"
+                      echo "✓ Published ${DEV_VERSION}"
+                    envVariables:
+                      ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
+                      ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
+                  description: Builds and publishes a dev version with the commit hash appended (e.g. 1.2.3.dev0+abc1234) to Artifactory on every primary branch merge.
+                  when:
+                    stageStatus: Success
+                    condition: <+pipeline.properties.ci.codebase.build.spec.branch> == <+pipeline.variables.primaryBranchName>
+        variables:
+          - name: pythonVersion
+            type: String
+            description: The python version to use, e.g. 3.10, 3.11, 3.12
+            required: true
+            value: "3.12"
+  variables:
+    - name: primaryBranchName
+      type: String
+      description: The name of the primary branch for the repo (e.g. master or main). Is used to determine whether the pipeline is running on the primary branch, which is used to determine whether or not the pipeline should attempt to publish.
+      required: true
+      value: main


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the build/publish CI pipeline runtime images and credential wiring for Artifactory publishing, which could break releases if `uv` install or auth behavior differs. No application/runtime code is modified.
> 
> **Overview**
> **Modernizes the Harness publish pipelines** by replacing the `ghcr.io/astral-sh/uv` image with `python:3.12-slim`, installing `uv` via the official install script, switching steps to `Bash`, and adding `set -euo pipefail` for stricter failure handling.
> 
> **Updates Artifactory publishing auth** to rely on `UV_PUBLISH_USERNAME`/`UV_PUBLISH_PASSWORD` env vars (and stops passing credentials via `uv publish --username/--password`), plus adds `set +x` in the dev publish step to reduce risk of secrets leaking if tracing is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4644143913d1508e8f9610172b83b296c4449ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->