### PR TITLE
[MMM-22501] fix

### DIFF
--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -103,23 +103,6 @@ pipeline:
             steps:
               - step:
                   type: Run
-                  name: Build Distribution
-                  identifier: Build_Distribution
-                  spec:
-                    connectorRef: account.dockerhub_datarobot_read
-                    image: datarobotdev/datarobot-opentelemetry:ci-python-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
-                    shell: Sh
-                    command: |-
-                      set -euo pipefail
-                      cd python/datarobot-opentelemetry
-                      uv build
-                      echo "Build complete. Artifacts:"
-                      ls -lh dist/
-                    envVariables:
-                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
-                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
-              - step:
-                  type: Run
                   name: Publish to Artifactory
                   identifier: Publish_to_Artifactory
                   spec:
@@ -131,13 +114,23 @@ pipeline:
                       cd python/datarobot-opentelemetry
                       PACKAGE_NAME=$(grep '^name' pyproject.toml | head -1 | awk -F'"' '{print $2}')
                       PACKAGE_VERSION=$(grep '^version' pyproject.toml | head -1 | awk -F'"' '{print $2}')
-                      
-                      echo "Publishing ${PACKAGE_NAME} v${PACKAGE_VERSION} to Artifactory..."
-                      set +x
-                      uv publish \
-                        --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
-                        --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
-                      echo "✓ Successfully published ${PACKAGE_NAME} v${PACKAGE_VERSION}"
+
+                      uv build
+
+                      # Check if it is safe to try to push - if the current version already exists in
+                      # artifactory, we won't even try to publish (but still keep the pipeline green)
+                      uv pip install ${PACKAGE_NAME}==${PACKAGE_VERSION} --dry-run
+                      EXIT_CODE=$?
+
+                      if [ $EXIT_CODE -eq 0 ]; then
+                        echo "Package already exists on artifactory, not trying to upload"
+                      else
+                        echo "Publishing ${PACKAGE_NAME} v${PACKAGE_VERSION} to Artifactory..."
+                        uv publish \
+                          --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
+                          --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
+                        echo "✓ Successfully published ${PACKAGE_NAME} v${PACKAGE_VERSION}"
+                      fi
                     envVariables:
                       UV_PUBLISH_USERNAME: <+variable.account.artifactory_username>
                       UV_PUBLISH_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>

--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -106,6 +106,8 @@ pipeline:
                   name: Build Distribution
                   identifier: Build_Distribution
                   spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: datarobotdev/datarobot-opentelemetry:ci-python-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
                     shell: Sh
                     command: |-
                       set -euo pipefail
@@ -121,6 +123,8 @@ pipeline:
                   name: Publish to Artifactory
                   identifier: Publish_to_Artifactory
                   spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: datarobotdev/datarobot-opentelemetry:ci-python-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
                     shell: Sh
                     command: |-
                       set -euo pipefail

--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -106,8 +106,6 @@ pipeline:
                   name: Build Distribution
                   identifier: Build_Distribution
                   spec:
-                    connectorRef: account.dockerhub_datarobot_read
-                    image: datarobotdev/datarobot-opentelemetry:ci-python-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
                     shell: Sh
                     command: |-
                       set -euo pipefail
@@ -115,13 +113,14 @@ pipeline:
                       uv build
                       echo "Build complete. Artifacts:"
                       ls -lh dist/
+                    envVariables:
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
               - step:
                   type: Run
                   name: Publish to Artifactory
                   identifier: Publish_to_Artifactory
                   spec:
-                    connectorRef: account.dockerhub_datarobot_read
-                    image: datarobotdev/datarobot-opentelemetry:ci-python-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
                     shell: Sh
                     command: |-
                       set -euo pipefail
@@ -138,6 +137,8 @@ pipeline:
                     envVariables:
                       UV_PUBLISH_USERNAME: <+variable.account.artifactory_username>
                       UV_PUBLISH_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
                   when:
                     stageStatus: Success
                     condition: <+pipeline.properties.ci.codebase.build.spec.branch> == <+pipeline.variables.primaryBranchName>

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -147,6 +147,8 @@ pipeline:
                   name: Publish Dev Version
                   identifier: Maybe_Publish
                   spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: datarobotdev/datarobot-opentelemetry:ci-python-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
                     shell: Sh
                     command: |-
                       set -euo pipefail

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -147,8 +147,6 @@ pipeline:
                   name: Publish Dev Version
                   identifier: Maybe_Publish
                   spec:
-                    connectorRef: account.dockerhub_datarobot_read
-                    image: datarobotdev/datarobot-opentelemetry:ci-python-<+pipeline.stages.Git_Hash.spec.execution.steps.Git_Hash.output.outputVariables.GIT_HASH_SHORT>
                     shell: Sh
                     command: |-
                       set -euo pipefail
@@ -181,6 +179,8 @@ pipeline:
                     envVariables:
                       UV_PUBLISH_USERNAME: <+variable.account.artifactory_username>
                       UV_PUBLISH_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>
+                      UV_INDEX_DR_ARTIFACTORY_USERNAME: <+variable.account.artifactory_username>
                   description: Builds and publishes a dev version with the commit hash appended (e.g. 1.2.3.dev0+abc1234) to Artifactory on every primary branch merge.
                   when:
                     stageStatus: Success

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -171,13 +171,21 @@ pipeline:
                       # which is why we have to inject UV_INDEX_DR_ARTIFACTORY credentials
                       uv build
 
-                      echo "Publishing ${PACKAGE_NAME} ${DEV_VERSION} to Artifactory..."
-                      # Prevent secret expansion from being printed if xtrace is enabled upstream.
-                      set +x
-                      uv publish \
-                        --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
-                        --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
-                      echo "✓ Published ${DEV_VERSION}"
+                      uv pip install ${PACKAGE_NAME}==${DEV_VERSION} --dry-run
+                      EXIT_CODE=$?
+
+                      if [ $EXIT_CODE -eq 0 ]; then
+                        echo "Package already exists on artifactory, not trying to upload"
+
+                      else
+                        echo "Publishing ${PACKAGE_NAME} ${DEV_VERSION} to Artifactory..."
+                        # Prevent secret expansion from being printed if xtrace is enabled upstream.
+                        set +x
+                        uv publish \
+                          --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
+                          --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
+                        echo "✓ Published ${DEV_VERSION}"
+                      fi
                     envVariables:
                       UV_PUBLISH_USERNAME: <+variable.account.artifactory_username>
                       UV_PUBLISH_PASSWORD: <+secrets.getValue("account.jenkins_upload_artifactory_password")>


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release/publish pipeline behavior and Artifactory credential usage; mistakes could cause unintended skipped publishes or publish failures on the primary branch.
> 
> **Overview**
> Makes the Artifactory publish steps in `Publish.yaml` and `Publish_dev.yaml` *idempotent* by building the package and then checking whether the target version already exists (`uv pip install ... --dry-run`); if it does, the pipeline skips `uv publish` while still succeeding.
> 
> Also removes the separate “Build Distribution” step from `Publish.yaml` by moving `uv build` into the publish step, and injects `UV_INDEX_DR_ARTIFACTORY_{USERNAME,PASSWORD}` env vars to ensure `uv build`/index access has the needed credentials.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6da845c8fce98831798f6e9bf0194a23d295b521. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->