### PR TITLE
[MMM-22501] fix

### DIFF
--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -115,18 +115,21 @@ pipeline:
                       PACKAGE_NAME=$(grep '^name' pyproject.toml | head -1 | awk -F'"' '{print $2}')
                       PACKAGE_VERSION=$(grep '^version' pyproject.toml | head -1 | awk -F'"' '{print $2}')
 
-                      uv build
+                      rm -rf /tmp/dist && mkdir -p /tmp/dist
+                      uv build --out-dir /tmp/dist
 
                       # Check if it is safe to try to push - if the current version already exists in
                       # artifactory, we won't even try to publish (but still keep the pipeline green)
+                      set +e
                       uv pip install ${PACKAGE_NAME}==${PACKAGE_VERSION} --dry-run
                       EXIT_CODE=$?
+                      set -e
 
                       if [ $EXIT_CODE -eq 0 ]; then
                         echo "Package already exists on artifactory, not trying to upload"
                       else
                         echo "Publishing ${PACKAGE_NAME} v${PACKAGE_VERSION} to Artifactory..."
-                        uv publish \
+                        uv publish /tmp/dist/* \
                           --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
                           --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
                         echo "✓ Successfully published ${PACKAGE_NAME} v${PACKAGE_VERSION}"

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -169,10 +169,13 @@ pipeline:
 
                       # n.b. `uv build` uses a separate compartmentalized environment to build
                       # which is why we have to inject UV_INDEX_DR_ARTIFACTORY credentials
-                      uv build
+                      rm -rf /tmp/dist && mkdir -p /tmp/dist
+                      uv build --out-dir /tmp/dist
 
+                      set +e
                       uv pip install ${PACKAGE_NAME}==${DEV_VERSION} --dry-run
                       EXIT_CODE=$?
+                      set -e
 
                       if [ $EXIT_CODE -eq 0 ]; then
                         echo "Package already exists on artifactory, not trying to upload"
@@ -181,7 +184,7 @@ pipeline:
                         echo "Publishing ${PACKAGE_NAME} ${DEV_VERSION} to Artifactory..."
                         # Prevent secret expansion from being printed if xtrace is enabled upstream.
                         set +x
-                        uv publish \
+                        uv publish /tmp/dist/* \
                           --check-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" \
                           --publish-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/datarobot-python-dev"
                         echo "✓ Published ${DEV_VERSION}"


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release/dev publishing pipeline scripts, which can directly affect whether packages are built and uploaded correctly to Artifactory. Risk is moderate due to impact on CI release flow but scope is limited to build/publish commands.
> 
> **Overview**
> **Publishing pipelines now build to an explicit `/tmp/dist` output directory and publish those artifacts** (via `uv build --out-dir /tmp/dist` and `uv publish /tmp/dist/*`) instead of relying on default build output.
> 
> The Artifactory “already exists” check (`uv pip install ... --dry-run`) is wrapped with `set +e`/`set -e` so a failed probe doesn’t abort the step before the conditional publish logic runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39dea698fd3b2d6c815e68da3e46ffd98dfd1c9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->