### PR TITLE
[MMM-22501] Added changelog

### DIFF
--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -115,6 +115,11 @@ pipeline:
                       PACKAGE_NAME=$(grep '^name' pyproject.toml | head -1 | awk -F'"' '{print $2}')
                       PACKAGE_VERSION=$(grep '^version' pyproject.toml | head -1 | awk -F'"' '{print $2}')
 
+                      if ! grep -q "^## \[${PACKAGE_VERSION}\]" CHANGELOG.md; then
+                        echo "ERROR: Missing release notes for version ${PACKAGE_VERSION} in CHANGELOG.md"
+                        exit 1
+                      fi
+
                       rm -rf /tmp/dist && mkdir -p /tmp/dist
                       uv build --out-dir /tmp/dist
 

--- a/python/datarobot-opentelemetry/CHANGELOG.md
+++ b/python/datarobot-opentelemetry/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.1.1] - 2026-03-30
+
+### Changed
+
+- Updated package metadata to support Python 3.10+.
+
+## [0.1.0] - 2026-03-30
+
+### Added
+
+- Initial release of datarobot-opentelemetry.
+- OpenTelemetry semantic convention constants in `datarobot_opentelemetry.semconv.SpanAttributes`.

--- a/python/datarobot-opentelemetry/README.md
+++ b/python/datarobot-opentelemetry/README.md
@@ -36,4 +36,8 @@ All constants live in `datarobot_opentelemetry.semconv.SpanAttributes`.
 
 ## Requirements
 
-- Python 3.12+
+- Python 3.10+
+
+## Release History
+
+- See CHANGELOG.md for version-by-version release notes.


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/CI guardrail change; main impact is that releases will now fail if changelog entries are missing.
> 
> **Overview**
> Adds a new `python/datarobot-opentelemetry/CHANGELOG.md` with initial release notes and updates `README.md` to reflect Python 3.10+ support and point users to the changelog.
> 
> Updates the Harness `Publish` pipeline to *fail publishing* if the current `pyproject.toml` version does not have a corresponding `## [<version>]` entry in `CHANGELOG.md`, enforcing release notes for every published version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd0f08bcb22a956a4a51a895a4389cf3fe480e80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->