### PR TITLE
[MMM-22501] fix test in publish dev

### DIFF
--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -114,12 +114,12 @@ pipeline:
                         shell: Sh
                         command: |-
                           cd python/datarobot-opentelemetry
-                          uv run --no-sync python3 -m pytest tests/ --junit-xml test-results.xml
+                          uv run --no-sync python3 -m pytest tests/ --junit-xml /harness/test_results/test-results.xml
                         reports:
                           type: JUnit
                           spec:
                             paths:
-                              - python/datarobot-opentelemetry/test-results.xml
+                              - /harness/test_results/test-results.xml
                   - step:
                       type: Run
                       name: Run Formatter Check


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just relocates the pytest JUnit XML output/report path; main risk is tests appearing missing if the new path is incorrect in the Harness environment.
> 
> **Overview**
> Updates the `Publish_dev` Harness pipeline to have pytest write its JUnit XML to `/harness/test_results/test-results.xml`, and points the JUnit report collector at the same location so test results are properly discovered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e0b60d2d3c609274d287d3b94f0e835d27e419f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->