### PR TITLE
[MMM-22501] fix

### DIFF
--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -153,7 +153,8 @@ pipeline:
                     command: |-
                       set -euo pipefail
 
-                      cd python/datarobot-opentelemetry
+                      cp -r python/datarobot-opentelemetry /tmp/build-workspace
+                      cd /tmp/build-workspace
 
                       export PACKAGE_NAME=$(uv version | awk '{print $1}')
                       export BASE_VERSION=$(uv version --short)

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -153,17 +153,22 @@ pipeline:
                     command: |-
                       set -euo pipefail
 
-                      cp -r python/datarobot-opentelemetry /tmp/build-workspace
-                      cd /tmp/build-workspace
-
+                      # Extract git info and version while in the repo context
+                      cd python/datarobot-opentelemetry
+                      export COMMIT_HASH=$(git rev-parse --short HEAD)
                       export PACKAGE_NAME=$(uv version | awk '{print $1}')
                       export BASE_VERSION=$(uv version --short)
-                      export COMMIT_HASH=$(git rev-parse --short HEAD)
+                      cd ../..
+
                       export DEV_VERSION="${BASE_VERSION}.dev0+${COMMIT_HASH}"
 
                       echo "Package:      ${PACKAGE_NAME}"
                       echo "Base version: ${BASE_VERSION}"
                       echo "Dev version:  ${DEV_VERSION}"
+
+                      # Copy to writable location for modification
+                      cp -r python/datarobot-opentelemetry /tmp/build-workspace
+                      cd /tmp/build-workspace
 
                       # Stamp the dev version into pyproject.toml before building
                       sed -i "s/^version = \"${BASE_VERSION}\"/version = \"${DEV_VERSION}\"/" pyproject.toml


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release/publish pipeline flow and filesystem paths, which could break dev-version stamping or artifact publishing if the new working directory assumptions are wrong.
> 
> **Overview**
> **Fixes the dev publish step in Harness CI** by extracting git/version info while still inside the checked-out repo, then switching back to the workspace root.
> 
> To avoid modifying a potentially read-only checkout, the pipeline now copies `python/datarobot-opentelemetry` to `/tmp/build-workspace` and performs the `pyproject.toml` version stamp and `uv build` from that writable location before proceeding with the existing publish/skip-if-exists logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 411c92862d99f108c9c524144f05babe1a702cbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->