### PR TITLE
[MMM-22501] fix check

### DIFF
--- a/.harness/Publish.yaml
+++ b/.harness/Publish.yaml
@@ -126,7 +126,8 @@ pipeline:
                       # Check if it is safe to try to push - if the current version already exists in
                       # artifactory, we won't even try to publish (but still keep the pipeline green)
                       set +e
-                      uv pip install ${PACKAGE_NAME}==${PACKAGE_VERSION} --dry-run
+                      uv pip install ${PACKAGE_NAME}==${PACKAGE_VERSION} --dry-run \
+                        --index-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple"
                       EXIT_CODE=$?
                       set -e
 

--- a/.harness/Publish_dev.yaml
+++ b/.harness/Publish_dev.yaml
@@ -179,7 +179,8 @@ pipeline:
                       uv build --out-dir /tmp/dist
 
                       set +e
-                      uv pip install ${PACKAGE_NAME}==${DEV_VERSION} --dry-run
+                      uv pip install ${PACKAGE_NAME}==${DEV_VERSION} --dry-run \
+                        --index-url "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple"
                       EXIT_CODE=$?
                       set -e
 


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that only affects the pre-publish existence check by pointing it at a specific Artifactory PyPI index; publishing endpoints and build steps are unchanged.
> 
> **Overview**
> Updates the Harness publish pipelines to make the "package already exists" probe deterministic by adding an explicit `--index-url` to the `uv pip install ... --dry-run` check in both `Publish.yaml` and `Publish_dev.yaml`.
> 
> This ensures the version-existence check consults the intended Artifactory PyPI index before deciding whether to upload, without changing the actual `uv publish` destinations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e8b421673c01b26f8b476e9f94989e19bcb9a0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->