### PR TITLE
[-] Create otel_span annotation

### DIFF
--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/annotations/__init__.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/annotations/__init__.py
@@ -1,0 +1,3 @@
+from .traces import otel_span
+
+__all__ = ["otel_span"]

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/annotations/traces.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/annotations/traces.py
@@ -1,0 +1,70 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# DataRobot, Inc. Confidential.
+#
+# This is unpublished proprietary source code of DataRobot, Inc.
+# and its affiliates.
+#
+# The copyright notice above does not evidence any actual or intended
+# publication of such source code.
+import inspect
+from functools import wraps
+from typing import Optional
+
+from opentelemetry.trace import Tracer, get_tracer_provider
+
+from datarobot_opentelemetry.semconv.traces import TRACER_NAME
+
+
+def otel_span(
+    name: Optional[str] = None,
+    tracer: Optional[Tracer] = None,
+    attributes: Optional[dict[str, str]] = None,
+):
+    """Decorator: wrap a sync function, async coroutine, or async generator in an OTel span.
+
+    Span name defaults to the decorated function's ``__name__``.
+    ``isasyncgenfunction`` is checked before ``iscoroutinefunction`` because async
+    generators satisfy the coroutine check in some Python builds.
+    """
+
+    def decorator(func):
+        _name = name or func.__name__
+        _tracer = tracer or get_tracer_provider().get_tracer(TRACER_NAME)
+
+        def _set_attributes(s, attributes: Optional[dict[str, str]]):
+            for k, v in (attributes or {}).items():
+                s.set_attribute(k, v)
+
+        if inspect.isasyncgenfunction(func):
+
+            @wraps(func)
+            async def async_gen_wrapper(*args, **kwargs):
+                with _tracer.start_as_current_span(_name) as span:
+                    _set_attributes(span)
+                    async for item in func(*args, **kwargs):
+                        yield item
+
+            return async_gen_wrapper
+
+        if inspect.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                with _tracer.start_as_current_span(_name) as span:
+                    _set_attributes(span, attributes)
+                    return await func(*args, **kwargs)
+
+            return async_wrapper
+
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            with _tracer.start_as_current_span(_name) as span:
+                _set_attributes(span, attributes)
+                return func(*args, **kwargs)
+
+        return sync_wrapper
+
+    return decorator

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/annotations/traces.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/annotations/traces.py
@@ -34,7 +34,8 @@ def otel_span(
         _name = name or func.__name__
         _tracer = tracer or get_tracer_provider().get_tracer(TRACER_NAME)
 
-        def _set_attributes(s, attributes: Optional[dict[str, str]]):
+        def _set_attributes(s):
+            """Use outer `attributes` to set the span attributes."""
             for k, v in (attributes or {}).items():
                 s.set_attribute(k, v)
 
@@ -54,7 +55,7 @@ def otel_span(
             @wraps(func)
             async def async_wrapper(*args, **kwargs):
                 with _tracer.start_as_current_span(_name) as span:
-                    _set_attributes(span, attributes)
+                    _set_attributes(span)
                     return await func(*args, **kwargs)
 
             return async_wrapper
@@ -62,7 +63,7 @@ def otel_span(
         @wraps(func)
         def sync_wrapper(*args, **kwargs):
             with _tracer.start_as_current_span(_name) as span:
-                _set_attributes(span, attributes)
+                _set_attributes(span)
                 return func(*args, **kwargs)
 
         return sync_wrapper

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/integrations/configuration.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/integrations/configuration.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Optional, cast
 
 from datarobot_opentelemetry.semconv.headers import DataRobotOtelHeaders
+from datarobot_opentelemetry.semconv.traces import TRACER_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +154,7 @@ def configure(
     # Configure tracing
     try:
         trace_provider = cast(TracerProvider, trace.get_tracer_provider())
-        tracer = trace_provider.get_tracer(__name__)
+        tracer = trace_provider.get_tracer(TRACER_NAME)
         internal_tracer = getattr(tracer, "_tracer", None)
         trace_exporter = OTLPSpanExporter(
             endpoint=_signal_endpoint("traces"), headers=otel_headers

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/semconv/__init__.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/semconv/__init__.py
@@ -1,4 +1,4 @@
 from .headers import DataRobotOtelHeaders
-from .traces import SpanAttributes
+from .traces import TRACER_NAME, SpanAttributes
 
-__all__ = ["SpanAttributes", "DataRobotOtelHeaders"]
+__all__ = ["SpanAttributes", "DataRobotOtelHeaders", "TRACER_NAME"]

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/semconv/traces.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/semconv/traces.py
@@ -12,6 +12,8 @@
 
 from typing import Final
 
+TRACER_NAME = "datarobot"
+
 
 class SpanAttributes:
     """Constants for span attribute keys used in Gen AI telemetry."""

--- a/python/datarobot-opentelemetry/tests/unit/test_trace_annotation.py
+++ b/python/datarobot-opentelemetry/tests/unit/test_trace_annotation.py
@@ -1,0 +1,49 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# DataRobot, Inc. Confidential.
+#
+# This is unpublished proprietary source code of DataRobot, Inc.
+# and its affiliates.
+#
+# The copyright notice above does not evidence any actual or intended
+# publication of such source code.
+import pytest
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, InMemorySpanExporter
+
+from datarobot_opentelemetry.annotations import otel_span
+
+
+@pytest.fixture
+def memory_exporter() -> InMemorySpanExporter:
+    return InMemorySpanExporter()
+
+
+@pytest.fixture
+def tracer(memory_exporter: InMemorySpanExporter) -> Tracer:
+    memory_exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    span_processor = SimpleSpanProcessor(memory_exporter)
+    tracer_provider.add_span_processor(span_processor)
+    trace.set_tracer_provider(tracer_provider)
+    return tracer_provider.get_tracer(TRACER_NAME)
+
+
+def test_trace_annotation_sync(memory_exporter: InMemorySpanExporter, tracer: Tracer) -> None:
+     @otel_span("sna", tracer=tracer, attributes={"foo": "bar"})
+     def func2(a: int, b: int) -> int:
+         return a + b
+
+     @otel_span(tracer=tracer)
+     def func1(a: int, b: int, c: int) -> int:
+         return func2(a, b) * c
+
+     assert func1(1, 2, 3) == 9
+
+     captured_spans = memory_exporter.get_finished_spans()
+     assert len(captured_spans) == 2
+     # TODO: more checks -- names on each

--- a/python/datarobot-opentelemetry/tests/unit/test_trace_annotation.py
+++ b/python/datarobot-opentelemetry/tests/unit/test_trace_annotation.py
@@ -25,7 +25,6 @@ def memory_exporter() -> InMemorySpanExporter:
 
 @pytest.fixture
 def tracer(memory_exporter: InMemorySpanExporter) -> Tracer:
-    memory_exporter = InMemorySpanExporter()
     tracer_provider = TracerProvider()
     span_processor = SimpleSpanProcessor(memory_exporter)
     tracer_provider.add_span_processor(span_processor)


### PR DESCRIPTION
## Summary

Create an `otel_span` annotation for instantiating a span for a function.

## Rationale

This provides an easy means for creating a span whose duration matches the function it wraps. 

For example:
```Python
from datarobot_opentelemetry.annotations import otel_span

@otel_span("span-for-function-below")
def my_function(a: Any, b: int) -> int:
    a_len = len(a) if isinstance(a, (dict, list)) else 0
    return b +
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only API and tracer naming; no auth or data-path changes, though async-generator attribute wiring in the diff looks inconsistent with other wrappers.
> 
> **Overview**
> Adds an **`otel_span`** decorator so callers can wrap sync functions, async coroutines, and async generators in OpenTelemetry spans whose lifetime matches the wrapped callable. Span names default to the function name; optional custom name, tracer, and string attributes are supported.
> 
> Introduces a shared **`TRACER_NAME`** (`"datarobot"`) in semconv and switches **`configure()`** (and the decorator’s default tracer) to use that name instead of module-specific tracer names, so manual spans align with the configured SDK tracer.
> 
> Exports **`otel_span`** from `datarobot_opentelemetry.annotations` and adds a minimal unit test for nested sync decorated functions (span count only; more assertions left as TODO). Reviewers should note the async-generator wrapper calls `_set_attributes` with only the span argument in the diff, unlike the sync/async paths that pass `attributes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54987d8d4231cf197d104700f906f8d5df5b23de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->