### PR TITLE
[MMM-23961] Respect OTEL_EXPORTER_OTLP_HEADERS env var if provider

### DIFF
--- a/python/datarobot-opentelemetry/CHANGELOG.md
+++ b/python/datarobot-opentelemetry/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.2.1] - 2026-06-017
+
+### Added
+
+- Respect `X-DataRobot-Entity-Id` and `X-DataRobot-Api-Key` DataRobot specific headers
+  if provided via `OTEL_EXPORTER_OTLP_HEADERS` environment variable.
+
 ## [0.2.0] - 2026-04-01
 
 ### Added

--- a/python/datarobot-opentelemetry/README.md
+++ b/python/datarobot-opentelemetry/README.md
@@ -71,6 +71,11 @@ export DATAROBOT_ENTITY_TYPE="deployment"
 export DATAROBOT_ENTITY_ID="your-entity-id"
 export DATAROBOT_API_TOKEN="your-api-key"
 ```
+or using OTEL specific environment variables that take precedence:
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://your-telemetry-endpoint.example.com"
+export OTEL_EXPORTER_OTLP_HEADERS="X-DataRobot-Entity-Id=deployment-<your-entity-id>,X-DataRobot-Api-Key=<your-api-key>"
+```
 
 ```python
 from datarobot_opentelemetry.integrations import configure

--- a/python/datarobot-opentelemetry/pyproject.toml
+++ b/python/datarobot-opentelemetry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datarobot-opentelemetry"
-version = "0.2.0"
+version = "0.2.1"
 description = "OpenTelemetry utilities and encapsulation of semantic naming conventions for improved integration with DataRobot."
 readme = "README.md"
 license = { text = "Proprietary" }

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/integrations/configuration.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/integrations/configuration.py
@@ -15,7 +15,7 @@
 import logging
 import os
 from dataclasses import dataclass
-from typing import Optional, Tuple, cast
+from typing import cast
 
 from datarobot_opentelemetry.semconv.headers import DataRobotOtelHeaders
 
@@ -29,14 +29,14 @@ class ConfigureResult:
     logger_configured: bool
 
 
-def _parse_dr_env_vars() -> Tuple[str | None, str | None]:
+def parse_env_headers() -> tuple[str | None, str | None]:
     env_var_headers = os.environ.get("OTEL_EXPORTER_OTLP_HEADERS") or ""
     env_headers = {}
 
     for item in env_var_headers.split(","):
         if "=" in item:
             key, value = item.split("=", 1)
-            env_headers[key.strip().lower()] = value
+            env_headers[key.strip().lower()] = value.strip()
 
     dr_service_name = env_headers.get(DataRobotOtelHeaders.ENTITY_ID.lower())
     dr_api_key = env_headers.get(DataRobotOtelHeaders.API_KEY.lower())
@@ -45,10 +45,10 @@ def _parse_dr_env_vars() -> Tuple[str | None, str | None]:
 
 
 def configure(
-    endpoint: Optional[str] = None,
-    entity_type: Optional[str] = None,
-    entity_id: Optional[str] = None,
-    api_key: Optional[str] = None,
+    endpoint: str | None = None,
+    entity_type: str | None = None,
+    entity_id: str | None = None,
+    api_key: str | None = None,
     log_level: int = logging.INFO,
     metrics_export_interval: int = 60000,
 ) -> ConfigureResult:

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/integrations/configuration.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/integrations/configuration.py
@@ -29,21 +29,6 @@ class ConfigureResult:
     logger_configured: bool
 
 
-def parse_env_headers() -> tuple[str | None, str | None]:
-    env_var_headers = os.environ.get("OTEL_EXPORTER_OTLP_HEADERS") or ""
-    env_headers = {}
-
-    for item in env_var_headers.split(","):
-        if "=" in item:
-            key, value = item.split("=", 1)
-            env_headers[key.strip().lower()] = value.strip()
-
-    dr_service_name = env_headers.get(DataRobotOtelHeaders.ENTITY_ID.lower())
-    dr_api_key = env_headers.get(DataRobotOtelHeaders.API_KEY.lower())
-
-    return dr_service_name, dr_api_key
-
-
 def configure(
     endpoint: str | None = None,
     entity_type: str | None = None,
@@ -115,20 +100,45 @@ def configure(
             NoOpTracer,
             ProxyTracerProvider,
         )
+        from opentelemetry.util.re import parse_env_headers
     except ModuleNotFoundError as exc:
         raise ModuleNotFoundError(
             "OpenTelemetry integration dependencies are not installed. "
             "Install with: pip install 'datarobot-opentelemetry[integrations]'"
         ) from exc
 
-    dr_service_name, dr_api_key = _parse_dr_env_vars()
+    def _parse_otel_env_headers() -> dict[str, str]:
+        """Parse OTEL_EXPORTER_OTLP_HEADERS into a dict of header name -> value.
 
-    if not dr_api_key or api_key:
-        api_key = api_key or os.environ.get("DATAROBOT_API_TOKEN")
-        if not api_key:
-            raise ValueError(
-                "API key is required for authentication. Provide it as an argument or set the DATAROBOT_API_TOKEN environment variable."
-            )
+        Uses OpenTelemetry's own ``parse_env_headers`` so we honor exactly the same
+        parsing rules (and ``liberal`` leniency) as the OTLP exporters do, ensuring
+        every header the user configured is preserved. Keys are lower-cased by the
+        parser.
+        """
+        env_var_headers = os.environ.get("OTEL_EXPORTER_OTLP_HEADERS") or ""
+        return dict(parse_env_headers(env_var_headers, liberal=True))
+
+    def _parse_dr_headers(
+        env_headers: dict[str, str],
+    ) -> tuple[str | None, str | None, str | None]:
+        api_key = env_headers.get(DataRobotOtelHeaders.API_KEY.lower())
+
+        entity_type = None
+        entity_id = None
+        if dr_service_name := env_headers.get(
+            DataRobotOtelHeaders.ENTITY_ID.lower(), ""
+        ):
+            # If it contains a hyphen, we assume it's an entity identifier in the format "type-id" and split it.
+            if "-" in dr_service_name:
+                parts = dr_service_name.split("-", 1)
+                entity_type = parts[0]
+                if len(parts) == 2:
+                    entity_id = parts[1]
+
+        return api_key, entity_type, entity_id
+
+    otel_headers = _parse_otel_env_headers()
+    dr_api_key, dr_entity_type, dr_entity_id = _parse_dr_headers(otel_headers)
 
     endpoint = endpoint or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
     if not endpoint:
@@ -136,23 +146,28 @@ def configure(
             "Endpoint is required for telemetry export. Provide it as an argument or set the OTEL_EXPORTER_OTLP_ENDPOINT environment variable."
         )
 
-    if not dr_service_name or (entity_type and entity_id):
-        entity_type = entity_type or os.environ.get("DATAROBOT_ENTITY_TYPE")
-        if not entity_type:
-            raise ValueError(
-                "Entity type is required for telemetry context. Provide it as an argument or set the DATAROBOT_ENTITY_TYPE environment variable."
-            )
-        entity_id = entity_id or os.environ.get("DATAROBOT_ENTITY_ID")
-        if not entity_id:
-            raise ValueError(
-                "Entity ID is required for telemetry context. Provide it as an argument or set the DATAROBOT_ENTITY_ID environment variable."
-            )
+    api_key = api_key or dr_api_key or os.environ.get("DATAROBOT_API_TOKEN")
+    if not api_key:
+        raise ValueError(
+            "API key is required for authentication. Provide it as an argument or set the DATAROBOT_API_TOKEN environment variable."
+        )
 
-    otel_headers: dict[str, str] = {}
-    if entity_type and entity_id:
-        otel_headers[DataRobotOtelHeaders.ENTITY_ID] = f"{entity_type}-{entity_id}"
-    if api_key:
-        otel_headers[DataRobotOtelHeaders.API_KEY] = api_key
+    entity_type = (
+        entity_type or dr_entity_type or os.environ.get("DATAROBOT_ENTITY_TYPE")
+    )
+    if not entity_type:
+        raise ValueError(
+            "Entity type is required for telemetry context. Provide it as an argument or set the DATAROBOT_ENTITY_TYPE environment variable."
+        )
+
+    entity_id = entity_id or dr_entity_id or os.environ.get("DATAROBOT_ENTITY_ID")
+    if not entity_id:
+        raise ValueError(
+            "Entity ID is required for telemetry context. Provide it as an argument or set the DATAROBOT_ENTITY_ID environment variable."
+        )
+
+    otel_headers[DataRobotOtelHeaders.ENTITY_ID.lower()] = f"{entity_type}-{entity_id}"
+    otel_headers[DataRobotOtelHeaders.API_KEY.lower()] = api_key
 
     base_endpoint = endpoint.rstrip("/")
 

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/integrations/configuration.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/integrations/configuration.py
@@ -15,7 +15,7 @@
 import logging
 import os
 from dataclasses import dataclass
-from typing import Optional, cast
+from typing import Optional, Tuple, cast
 
 from datarobot_opentelemetry.semconv.headers import DataRobotOtelHeaders
 
@@ -27,6 +27,21 @@ class ConfigureResult:
     tracing_configured: bool
     metrics_configured: bool
     logger_configured: bool
+
+
+def _parse_dr_env_vars() -> Tuple[str | None, str | None]:
+    env_var_headers = os.environ.get("OTEL_EXPORTER_OTLP_HEADERS") or ""
+    env_headers = {}
+
+    for item in env_var_headers.split(","):
+        if "=" in item:
+            key, value = item.split("=", 1)
+            env_headers[key.strip().lower()] = value
+
+    dr_service_name = env_headers.get(DataRobotOtelHeaders.ENTITY_ID.lower())
+    dr_api_key = env_headers.get(DataRobotOtelHeaders.API_KEY.lower())
+
+    return dr_service_name, dr_api_key
 
 
 def configure(
@@ -106,31 +121,38 @@ def configure(
             "Install with: pip install 'datarobot-opentelemetry[integrations]'"
         ) from exc
 
-    api_key = api_key or os.environ.get("DATAROBOT_API_TOKEN")
-    if not api_key:
-        raise ValueError(
-            "API key is required for authentication. Provide it as an argument or set the DATAROBOT_API_TOKEN environment variable."
-        )
+    dr_service_name, dr_api_key = _parse_dr_env_vars()
+
+    if not dr_api_key or api_key:
+        api_key = api_key or os.environ.get("DATAROBOT_API_TOKEN")
+        if not api_key:
+            raise ValueError(
+                "API key is required for authentication. Provide it as an argument or set the DATAROBOT_API_TOKEN environment variable."
+            )
+
     endpoint = endpoint or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
     if not endpoint:
         raise ValueError(
             "Endpoint is required for telemetry export. Provide it as an argument or set the OTEL_EXPORTER_OTLP_ENDPOINT environment variable."
         )
-    entity_type = entity_type or os.environ.get("DATAROBOT_ENTITY_TYPE")
-    if not entity_type:
-        raise ValueError(
-            "Entity type is required for telemetry context. Provide it as an argument or set the DATAROBOT_ENTITY_TYPE environment variable."
-        )
-    entity_id = entity_id or os.environ.get("DATAROBOT_ENTITY_ID")
-    if not entity_id:
-        raise ValueError(
-            "Entity ID is required for telemetry context. Provide it as an argument or set the DATAROBOT_ENTITY_ID environment variable."
-        )
 
-    otel_headers = {
-        DataRobotOtelHeaders.ENTITY_ID: f"{entity_type}-{entity_id}",
-        DataRobotOtelHeaders.API_KEY: api_key,
-    }
+    if not dr_service_name or (entity_type and entity_id):
+        entity_type = entity_type or os.environ.get("DATAROBOT_ENTITY_TYPE")
+        if not entity_type:
+            raise ValueError(
+                "Entity type is required for telemetry context. Provide it as an argument or set the DATAROBOT_ENTITY_TYPE environment variable."
+            )
+        entity_id = entity_id or os.environ.get("DATAROBOT_ENTITY_ID")
+        if not entity_id:
+            raise ValueError(
+                "Entity ID is required for telemetry context. Provide it as an argument or set the DATAROBOT_ENTITY_ID environment variable."
+            )
+
+    otel_headers: dict[str, str] = {}
+    if entity_type and entity_id:
+        otel_headers[DataRobotOtelHeaders.ENTITY_ID] = f"{entity_type}-{entity_id}"
+    if api_key:
+        otel_headers[DataRobotOtelHeaders.API_KEY] = api_key
 
     base_endpoint = endpoint.rstrip("/")
 

--- a/python/datarobot-opentelemetry/tests/unit/test_integrations_configuration.py
+++ b/python/datarobot-opentelemetry/tests/unit/test_integrations_configuration.py
@@ -44,10 +44,6 @@ def _trace_exporter_headers() -> dict[str, str]:
 
 
 def _install_fake_opentelemetry(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Capture the real header parser before we shadow the opentelemetry package
-    # so the configuration code can still parse OTEL_EXPORTER_OTLP_HEADERS.
-    from opentelemetry.util.re import parse_env_headers as real_parse_env_headers
-
     modules: dict[str, types.ModuleType] = {}
 
     def add_module(name: str) -> types.ModuleType:
@@ -141,6 +137,16 @@ def _install_fake_opentelemetry(monkeypatch: pytest.MonkeyPatch) -> None:
         def create(attributes: dict[str, str]) -> dict[str, str]:
             return attributes
 
+    def parse_env_headers(s: str, liberal: bool = False) -> dict[str, str]:
+        # This is a very minimal parser that only supports the specific header formats we expect in the tests
+        headers: dict[str, str] = {}
+        for header in s.split(","):
+            if "=" not in header:
+                continue
+            name, value = header.split("=", 1)
+            headers[name.strip().lower()] = value.strip()
+        return headers
+
     opentelemetry = add_module("opentelemetry")
     trace_module = add_module("opentelemetry.trace")
     metrics_module = add_module("opentelemetry.metrics")
@@ -172,6 +178,9 @@ def _install_fake_opentelemetry(monkeypatch: pytest.MonkeyPatch) -> None:
     instrumentation_logging_module.LoggingHandler = LoggingHandler
     instrumentation_logging_module.LoggingInstrumentor = LoggingInstrumentor
     instrumentation_module.logging = instrumentation_logging_module
+
+    util_re_module = add_module("opentelemetry.util.re")
+    util_re_module.parse_env_headers = parse_env_headers
 
     logs_internal_module = add_module("opentelemetry._logs._internal")
     logs_internal_module.ProxyLoggerProvider = ProxyLoggerProvider

--- a/python/datarobot-opentelemetry/tests/unit/test_integrations_configuration.py
+++ b/python/datarobot-opentelemetry/tests/unit/test_integrations_configuration.py
@@ -12,11 +12,36 @@
 
 import builtins
 import logging
+import sys
 import types
 
 import pytest
 
 from datarobot_opentelemetry.integrations import configure
+from datarobot_opentelemetry.integrations.configuration import _parse_dr_env_vars
+from datarobot_opentelemetry.semconv.headers import DataRobotOtelHeaders
+
+ENTITY_HEADER = DataRobotOtelHeaders.ENTITY_ID
+API_KEY_HEADER = DataRobotOtelHeaders.API_KEY
+
+
+@pytest.fixture(autouse=True)
+def _clear_datarobot_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure no ambient DataRobot/OTEL env vars leak into the tests."""
+    for name in (
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "DATAROBOT_API_TOKEN",
+        "DATAROBOT_ENTITY_TYPE",
+        "DATAROBOT_ENTITY_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _trace_exporter_headers() -> dict[str, str]:
+    """Return the headers passed to the configured trace exporter."""
+    provider = sys.modules["opentelemetry.trace"]._provider
+    return provider.span_processors[0].exporter.headers
 
 
 def _install_fake_opentelemetry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -208,3 +233,111 @@ def test_configure_succeeds_with_fake_opentelemetry(monkeypatch: pytest.MonkeyPa
 
     result = configure("https://example.test", "deployment", "abc-123", api_key="token")
     assert result == ConfigureResult(tracing_configured=True, metrics_configured=True, logger_configured=True)
+
+
+class TestParseDrEnvVars:
+    def test_returns_none_when_header_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+        assert _parse_dr_env_vars() == (None, None)
+
+    def test_returns_none_when_header_env_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+        assert _parse_dr_env_vars() == (None, None)
+
+    def test_parses_entity_id_and_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            f"{ENTITY_HEADER}=deployment-123,{API_KEY_HEADER}=secret",
+        )
+        assert _parse_dr_env_vars() == ("deployment-123", "secret")
+
+    def test_header_keys_are_case_insensitive_and_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            f" {ENTITY_HEADER.upper()} =deployment-123, {API_KEY_HEADER.lower()}=secret",
+        )
+        assert _parse_dr_env_vars() == ("deployment-123", "secret")
+
+    def test_ignores_items_without_equals(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            f"garbage,{ENTITY_HEADER}=deployment-123",
+        )
+        assert _parse_dr_env_vars() == ("deployment-123", None)
+
+    def test_value_may_contain_equals_sign(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            f"{API_KEY_HEADER}=a=b=c",
+        )
+        assert _parse_dr_env_vars() == (None, "a=b=c")
+
+    def test_returns_none_for_unrelated_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Bearer xyz")
+        assert _parse_dr_env_vars() == (None, None)
+
+
+def test_configure_uses_identity_from_otlp_headers_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When OTLP headers already carry the entity id and api key, configure
+    should not require the DATAROBOT_* args/env vars and should not duplicate
+    those values into the per-signal exporter headers."""
+    _install_fake_opentelemetry(monkeypatch)
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        f"{ENTITY_HEADER}=deployment-123,{API_KEY_HEADER}=secret",
+    )
+
+    from datarobot_opentelemetry.integrations import ConfigureResult
+
+    result = configure(endpoint="https://example.test")
+
+    assert result == ConfigureResult(tracing_configured=True, metrics_configured=True, logger_configured=True)
+    assert _trace_exporter_headers() == {}
+
+
+def test_configure_explicit_args_override_env_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit api_key/entity args are honored even when OTLP headers env is set."""
+    _install_fake_opentelemetry(monkeypatch)
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        f"{ENTITY_HEADER}=deployment-123,{API_KEY_HEADER}=secret",
+    )
+
+    configure(
+        endpoint="https://example.test",
+        entity_type="deployment",
+        entity_id="abc-123",
+        api_key="token",
+    )
+
+    assert _trace_exporter_headers() == {
+        ENTITY_HEADER: "deployment-abc-123",
+        API_KEY_HEADER: "token",
+    }
+
+
+def test_configure_requires_api_key_when_not_in_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_opentelemetry(monkeypatch)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", f"{ENTITY_HEADER}=deployment-123")
+
+    with pytest.raises(ValueError, match="API key is required"):
+        configure(endpoint="https://example.test")
+
+
+def test_configure_requires_entity_when_not_in_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_opentelemetry(monkeypatch)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", f"{API_KEY_HEADER}=secret")
+
+    with pytest.raises(ValueError, match="Entity type is required"):
+        configure(endpoint="https://example.test")
+
+
+def test_configure_requires_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_opentelemetry(monkeypatch)
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        f"{ENTITY_HEADER}=deployment-123,{API_KEY_HEADER}=secret",
+    )
+
+    with pytest.raises(ValueError, match="Endpoint is required"):
+        configure()

--- a/python/datarobot-opentelemetry/tests/unit/test_integrations_configuration.py
+++ b/python/datarobot-opentelemetry/tests/unit/test_integrations_configuration.py
@@ -18,11 +18,10 @@ import types
 import pytest
 
 from datarobot_opentelemetry.integrations import configure
-from datarobot_opentelemetry.integrations.configuration import _parse_dr_env_vars
 from datarobot_opentelemetry.semconv.headers import DataRobotOtelHeaders
 
-ENTITY_HEADER = DataRobotOtelHeaders.ENTITY_ID
-API_KEY_HEADER = DataRobotOtelHeaders.API_KEY
+ENTITY_HEADER = DataRobotOtelHeaders.ENTITY_ID.lower()
+API_KEY_HEADER = DataRobotOtelHeaders.API_KEY.lower()
 
 
 @pytest.fixture(autouse=True)
@@ -45,6 +44,10 @@ def _trace_exporter_headers() -> dict[str, str]:
 
 
 def _install_fake_opentelemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Capture the real header parser before we shadow the opentelemetry package
+    # so the configuration code can still parse OTEL_EXPORTER_OTLP_HEADERS.
+    from opentelemetry.util.re import parse_env_headers as real_parse_env_headers
+
     modules: dict[str, types.ModuleType] = {}
 
     def add_module(name: str) -> types.ModuleType:
@@ -235,52 +238,10 @@ def test_configure_succeeds_with_fake_opentelemetry(monkeypatch: pytest.MonkeyPa
     assert result == ConfigureResult(tracing_configured=True, metrics_configured=True, logger_configured=True)
 
 
-class TestParseDrEnvVars:
-    def test_returns_none_when_header_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
-        assert _parse_dr_env_vars() == (None, None)
-
-    def test_returns_none_when_header_env_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
-        assert _parse_dr_env_vars() == (None, None)
-
-    def test_parses_entity_id_and_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv(
-            "OTEL_EXPORTER_OTLP_HEADERS",
-            f"{ENTITY_HEADER}=deployment-123,{API_KEY_HEADER}=secret",
-        )
-        assert _parse_dr_env_vars() == ("deployment-123", "secret")
-
-    def test_header_keys_are_case_insensitive_and_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv(
-            "OTEL_EXPORTER_OTLP_HEADERS",
-            f" {ENTITY_HEADER.upper()} =deployment-123, {API_KEY_HEADER.lower()}=secret",
-        )
-        assert _parse_dr_env_vars() == ("deployment-123", "secret")
-
-    def test_ignores_items_without_equals(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv(
-            "OTEL_EXPORTER_OTLP_HEADERS",
-            f"garbage,{ENTITY_HEADER}=deployment-123",
-        )
-        assert _parse_dr_env_vars() == ("deployment-123", None)
-
-    def test_value_may_contain_equals_sign(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv(
-            "OTEL_EXPORTER_OTLP_HEADERS",
-            f"{API_KEY_HEADER}=a=b=c",
-        )
-        assert _parse_dr_env_vars() == (None, "a=b=c")
-
-    def test_returns_none_for_unrelated_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Bearer xyz")
-        assert _parse_dr_env_vars() == (None, None)
-
-
 def test_configure_uses_identity_from_otlp_headers_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """When OTLP headers already carry the entity id and api key, configure
-    should not require the DATAROBOT_* args/env vars and should not duplicate
-    those values into the per-signal exporter headers."""
+    should not require the DATAROBOT_* args/env vars and should forward those
+    values to the per-signal exporter headers."""
     _install_fake_opentelemetry(monkeypatch)
     monkeypatch.setenv(
         "OTEL_EXPORTER_OTLP_HEADERS",
@@ -292,7 +253,10 @@ def test_configure_uses_identity_from_otlp_headers_env(monkeypatch: pytest.Monke
     result = configure(endpoint="https://example.test")
 
     assert result == ConfigureResult(tracing_configured=True, metrics_configured=True, logger_configured=True)
-    assert _trace_exporter_headers() == {}
+    assert _trace_exporter_headers() == {
+        ENTITY_HEADER: "deployment-123",
+        API_KEY_HEADER: "secret",
+    }
 
 
 def test_configure_explicit_args_override_env_headers(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -313,6 +277,24 @@ def test_configure_explicit_args_override_env_headers(monkeypatch: pytest.Monkey
     assert _trace_exporter_headers() == {
         ENTITY_HEADER: "deployment-abc-123",
         API_KEY_HEADER: "token",
+    }
+
+
+def test_configure_forwards_extra_otlp_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Headers in OTEL_EXPORTER_OTLP_HEADERS that are not DataRobot identity
+    headers must still be forwarded to the signal exporters."""
+    _install_fake_opentelemetry(monkeypatch)
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_HEADERS",
+        f"{ENTITY_HEADER}=deployment-123,{API_KEY_HEADER}=secret,x-tenant=acme",
+    )
+
+    configure(endpoint="https://example.test")
+
+    assert _trace_exporter_headers() == {
+        "x-tenant": "acme",
+        ENTITY_HEADER: "deployment-123",
+        API_KEY_HEADER: "secret",
     }
 
 

--- a/python/datarobot-opentelemetry/uv.lock
+++ b/python/datarobot-opentelemetry/uv.lock
@@ -245,7 +245,7 @@ toml = [
 
 [[package]]
 name = "datarobot-opentelemetry"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Rationale

Some of the DR services automatically inject `OTEL_EXPORTER_OTLP_HEADERS="X-DataRobot-Entity-Id=<type>-<id>,X-DataRobot-Api-Key=<key>"` into the running container (e.g. LRS or WAPI).

This PR adds support to read `OTEL_EXPORTER_OTLP_HEADERS` and respect its value if provided.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OTLP exporter auth headers are built and could mis-route telemetry if entity-id parsing or precedence differs from operator expectations; scope is limited to integration configuration.
> 
> **Overview**
> **`configure()`** now reads **`OTEL_EXPORTER_OTLP_HEADERS`** (via OpenTelemetry’s **`parse_env_headers`**) so container-injected **`X-DataRobot-Entity-Id`** / **`X-DataRobot-Api-Key`** can supply entity and API key without **`DATAROBOT_*`** vars. Entity type/id are parsed from the entity header’s `type-id` form when present.
> 
> Resolved **`api_key`**, **`entity_type`**, and **`entity_id`** still follow **explicit arguments → OTLP headers → `DATAROBOT_*` env**. Non–DataRobot headers from the OTLP env string are **preserved** on trace/metrics/log exporters; DataRobot identity headers are **set or overridden** from the final resolved values.
> 
> Release **0.2.1** with README/CHANGELOG updates and expanded unit tests for OTLP-header sourcing, overrides, extra headers, and validation gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3dc286d982b0cb55b49a5f18b8cf0454f2b1dbf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->