### PR TITLE
Use actual github repo name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for your interest in contributing to this project.
 3. Install dependencies with uv.
 
 ```bash
-git clone https://github.com/datarobot/datarobot-opentelemetry-integration.git
+git clone git@github.com:datarobot-community/datarobot-opentelemetry-integration.git
 cd datarobot-opentelemetry-integration/python/datarobot-opentelemetry
 uv sync
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package provides OpenTelemetry semantic conventions and helper utilities us
 
 1. **Clone the repository**:
    ```bash
-   git clone https://github.com/datarobot/datarobot-opentelemetry-integration.git
+   git clone git@github.com:datarobot-community/datarobot-opentelemetry-integration.git
    cd datarobot-opentelemetry-integration
    ```
 

--- a/python/datarobot-opentelemetry/pyproject.toml
+++ b/python/datarobot-opentelemetry/pyproject.toml
@@ -28,8 +28,8 @@ integrations = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/datarobot/datarobot-opentelemetry-integration"
-Repository = "https://github.com/datarobot/datarobot-opentelemetry-integration"
+Homepage = "https://github.com/datarobot-community/datarobot-opentelemetry-integration"
+Repository = "https://github.com/datarobot-community/datarobot-opentelemetry-integration"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and package metadata URL changes only; no runtime or API behavior is affected.
> 
> **Overview**
> Updates **GitHub repository references** from `datarobot/datarobot-opentelemetry-integration` to **`datarobot-community/datarobot-opentelemetry-integration`**.
> 
> **`CONTRIBUTING.md`** and **`README.md`** now show an SSH clone URL (`git@github.com:datarobot-community/...`) instead of the old HTTPS `datarobot` org URL.
> 
> **`python/datarobot-opentelemetry/pyproject.toml`** **`[project.urls]`** `Homepage` and `Repository` are updated to the community org path so PyPI/metadata links match the actual repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ca1dd496c3b38a504f12cd27484639322ad5e7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->