### PR TITLE
Added agents.md and cursor rules

### DIFF
--- a/.cursor/rules/bugbot-python-review.mdc
+++ b/.cursor/rules/bugbot-python-review.mdc
@@ -1,0 +1,35 @@
+---
+description: Bugbot review checklist for risky Python changes in this repository
+globs:
+  - python/datarobot-opentelemetry/src/**/*.py
+  - python/datarobot-opentelemetry/tests/**/*.py
+alwaysApply: false
+---
+
+# Bugbot Python Review Rule
+
+When reviewing or generating changes in this repository, prioritize finding behavior regressions and safety issues before style concerns.
+
+## Review Priorities
+
+1. Confirm telemetry integration behavior remains backward compatible unless explicitly changed.
+2. Verify environment-variable precedence and configuration fallback logic are preserved.
+3. Ensure semantic convention constants remain stable and typo-free.
+4. Require unit tests for behavior changes, especially around `integrations/configuration.py` and `semconv` modules.
+5. Flag silent exception handling, overly broad `except Exception`, and dropped error context.
+
+## Required Checks Before Approving
+
+1. Run unit tests in package directory:
+   - `uv run pytest -v tests/unit`
+2. Run quality checks:
+   - `make lint`
+3. If headers or new files changed, run:
+   - `make license-check`
+
+## High-Risk Change Signals
+
+- Changes to public constants in `semconv`.
+- Changes to default exporter endpoints, headers, or auth behavior.
+- Changes to package versioning or release workflow files.
+- Added dependencies without justification in `pyproject.toml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Project Guidelines
+
+## Scope
+- These guidelines apply to the whole repository.
+- The primary code package is in `python/datarobot-opentelemetry`.
+
+## Architecture
+- This repository contains a Python package that provides:
+  - semantic conventions in `src/datarobot_opentelemetry/semconv`
+  - optional OpenTelemetry integration helpers in `src/datarobot_opentelemetry/integrations`
+- Keep public APIs stable and prefer additive changes.
+
+## Build And Test
+- Use `uv` for dependency and command execution.
+- Run commands from `python/datarobot-opentelemetry` unless a task explicitly targets repo root.
+- Core local validation commands:
+  - `make lint`
+  - `make test`
+  - `make ci`
+- Preferred fast unit-test command:
+  - `uv run pytest -v tests/unit`
+
+## Coding Conventions
+- Python version target is 3.10+ (see `pyproject.toml`).
+- Lint/format/type tools are authoritative:
+  - `ruff` for linting and formatting
+  - `mypy --strict` for typing
+- Add or update unit tests for behavior changes in `tests/unit`.
+- Keep changes focused; avoid unrelated refactors.
+
+## Release And Versioning
+- Package version is defined in `python/datarobot-opentelemetry/pyproject.toml`.
+- User-visible changes should include a changelog update in `python/datarobot-opentelemetry/CHANGELOG.md`.
+
+## Licensing
+- Source headers are validated via SkyWalking Eyes (`make license-check`).
+- Preserve existing header format and year pattern conventions in this repo.
+
+## References
+- See `README.md` for repo-level workflow and release process.
+- See `CONTRIBUTING.md` for contribution expectations.
+- See `python/datarobot-opentelemetry/Makefile` for canonical developer commands.


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and editor rules only; no runtime, API, or dependency changes.
> 
> **Overview**
> Adds **repository-wide agent guidance** in `AGENTS.md`: scope (`python/datarobot-opentelemetry`), architecture (semconv vs integrations), `uv`/Makefile validation (`make lint`, `test`, `ci`), ruff/mypy conventions, changelog/versioning, and licensing checks.
> 
> Adds a **Cursor rule** at `.cursor/rules/bugbot-python-review.mdc` scoped to package `src` and `tests` Python paths. It steers reviews toward telemetry backward compatibility, env/config precedence, stable semconv constants, tests for behavior changes, and flags risky patterns (silent/broad exception handling). It also lists required pre-approval commands and high-risk change signals (semconv public constants, exporter defaults/auth, versioning, new deps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca7bbc2fa29469d0d6f0e063e4eb43b5c743350. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->