### PR TITLE
[-] Add review router GitHub Actions workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file defines which domain owns what parts of the
+# repository. The syntax is the same as defined in
+
+# Default owners for everything in the repo.
+* @datarobot-oss/mmm

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -1,0 +1,27 @@
+name: Review Router
+
+# SECURITY: This workflow intentionally uses pull_request_target (not
+# pull_request) because review-router never checks out or executes PR code.
+# Do NOT add actions/checkout or shell run: blocks here.
+#
+# If you need to build or test PR code, use a separate workflow with the
+# pull_request trigger instead.
+#
+# See: https://github.com/datarobot-oss/review-router/blob/main/docs/security/pull-request-target.md
+
+on:
+  pull_request_target:
+    types: [labeled, opened, closed, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: "0 3,9,15,21 * * 1-5"
+
+jobs:
+  route:
+    uses: datarobot-oss/.github/.github/workflows/review-router.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Matches af-component-base's setup: delegates PR review routing and assignment to the shared datarobot-oss/.github reusable workflow instead of hand-rolling it here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with documented pull_request_target constraints and no checkout or execution of PR code in this workflow.
> 
> **Overview**
> Adds a **Review Router** workflow that wires this repo into the shared `datarobot-oss/.github` review-routing pipeline (same pattern as af-component-base), replacing any local/hand-rolled review assignment with the centralized reusable workflow.
> 
> The workflow runs on `pull_request_target` (labeled/opened/closed/ready_for_review), review events, issue comments, and a weekday cron at 03:00/09:00/15:00/21:00 UTC. The job calls `datarobot-oss/.github/.github/workflows/review-router.yml@main` with `secrets: inherit`. Inline comments document that **`pull_request_target` is intentional** because the router must not checkout or run PR code, and point to the org security doc for that pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1832ae0946f47f479fd161a04463fad7cb32d732. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->