### PR TITLE
[MMM-24846] Add agent Name

### DIFF
--- a/python/datarobot-opentelemetry/CHANGELOG.md
+++ b/python/datarobot-opentelemetry/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.4.0] - 2026-08-24
+
+### Added
+
+- `SpanAttributes.GEN_AI_AGENT_NAME` (`gen_ai.agent.name`), the OTel GenAI semantic
+  convention attribute for identifying the agent that produced a span.
+
 ## [0.3.0] - 2026-07-20
 
 ### Added

--- a/python/datarobot-opentelemetry/pyproject.toml
+++ b/python/datarobot-opentelemetry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datarobot-opentelemetry"
-version = "0.3.0"
+version = "0.4.0"
 description = "OpenTelemetry utilities and encapsulation of semantic naming conventions for improved integration with DataRobot."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/datarobot-opentelemetry/src/datarobot_opentelemetry/semconv/traces.py
+++ b/python/datarobot-opentelemetry/src/datarobot_opentelemetry/semconv/traces.py
@@ -28,6 +28,7 @@ class SpanAttributes:
     GEN_AI_USAGE_INPUT_TOKENS: Final = "gen_ai.usage.input_tokens"
     GEN_AI_USAGE_OUTPUT_TOKENS: Final = "gen_ai.usage.output_tokens"
     GEN_AI_TOOL_NAME: Final = "gen_ai.tool.name"
+    GEN_AI_AGENT_NAME: Final = "gen_ai.agent.name"
     ERROR_TYPE: Final = "error.type"
     SERVER_ADDRESS: Final = "server.address"
     SERVER_PORT: Final = "server.port"

--- a/python/datarobot-opentelemetry/tests/unit/test_smoke.py
+++ b/python/datarobot-opentelemetry/tests/unit/test_smoke.py
@@ -24,6 +24,7 @@ def test_gen_ai_standard_attributes() -> None:
     assert SpanAttributes.GEN_AI_RESPONSE_MODEL == "gen_ai.response.model"
     assert SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS == "gen_ai.usage.input_tokens"
     assert SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS == "gen_ai.usage.output_tokens"
+    assert SpanAttributes.GEN_AI_AGENT_NAME == "gen_ai.agent.name"
 
 
 def test_datarobot_specific_attributes() -> None:

--- a/python/datarobot-opentelemetry/uv.lock
+++ b/python/datarobot-opentelemetry/uv.lock
@@ -307,7 +307,7 @@ toml = [
 
 [[package]]
 name = "datarobot-opentelemetry"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary


## Rationale

<!-- rr:slack:start -->
<!-- rr:slack:CGNC37J7L:1787596821.225839 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive constant and version bump only; no changes to telemetry setup, export, or existing attribute behavior.
> 
> **Overview**
> Releases **datarobot-opentelemetry 0.4.0** with a new GenAI trace semantic constant so instrumented agents can tag spans with the producing agent’s identity.
> 
> Adds `SpanAttributes.GEN_AI_AGENT_NAME` (`gen_ai.agent.name`) in `semconv/traces.py`, documents it in **CHANGELOG**, bumps `pyproject.toml` / `uv.lock` to **0.4.0**, and extends the smoke test to assert the string value matches the OTel convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56018de09daa202dd8b1032d7ce60da03da428b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->