### PR TITLE
fix changelog

### DIFF
--- a/python/datarobot-opentelemetry/CHANGELOG.md
+++ b/python/datarobot-opentelemetry/CHANGELOG.md
@@ -2,18 +2,23 @@
 
 All notable changes to this project are documented in this file.
 
-## [0.4.0] - 2026-08-28
+## [0.4.1] - 2026-08-28
 
 ### Added
 
-- `SpanAttributes.GEN_AI_AGENT_NAME` (`gen_ai.agent.name`), the OTel GenAI semantic
-  convention attribute for identifying the agent that produced a span.
 - `DataRobotSpanKind.EVALUATOR` (`evaluator`) for identifying evaluator spans.
 - GenAI evaluation span attributes: `gen_ai.evaluation.name`,
   `gen_ai.evaluation.score.label`, `gen_ai.evaluation.score.value`, and
   `gen_ai.evaluation.explanation`.
 - `SpanAttributes.DATAROBOT_SPAN_KIND` (`datarobot.span.kind`) for recording
   DataRobot-specific span kinds.
+
+## [0.4.0] - 2026-08-24
+
+### Added
+
+- `SpanAttributes.GEN_AI_AGENT_NAME` (`gen_ai.agent.name`), the OTel GenAI semantic
+  convention attribute for identifying the agent that produced a span.
 
 ## [0.3.0] - 2026-07-20
 

--- a/python/datarobot-opentelemetry/pyproject.toml
+++ b/python/datarobot-opentelemetry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datarobot-opentelemetry"
-version = "0.4.0"
+version = "0.4.1"
 description = "OpenTelemetry utilities and encapsulation of semantic naming conventions for improved integration with DataRobot."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime or API code changes.
> 
> **Overview**
> **Bumps `datarobot-opentelemetry` to `0.4.1`** in `pyproject.toml` and **corrects `CHANGELOG.md`** so release notes match the intended versions.
> 
> The former single **0.4.0 (2026-08-28)** section is split: **`0.4.1`** now lists evaluator span kind, GenAI evaluation attributes, and `datarobot.span.kind`; **`0.4.0`** is restored as **2026-08-24** with only `gen_ai.agent.name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f28568375b4dc3616146f9f949f962704a3f26. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->